### PR TITLE
Add user info and authType

### DIFF
--- a/examples/testapp/src/components/RpcMethods/method/connectionMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/connectionMethods.ts
@@ -2,7 +2,10 @@ import { RpcRequestInput } from './RpcRequestInput';
 
 const ethRequestAccounts: RpcRequestInput = {
   method: 'eth_requestAccounts',
-  params: [],
+  params: [{
+    key: 'authType',
+    required: false,
+  }],
 };
 
 const ethAccounts: RpcRequestInput = {

--- a/examples/testapp/src/components/RpcMethods/method/walletTxMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/walletTxMethods.ts
@@ -6,6 +6,11 @@ const walletGetCapabilities: RpcRequestInput = {
   params: [],
 };
 
+const walletGetUserInfo: RpcRequestInput = {
+  method: 'wallet_getUserInfo',
+  params: [],
+};
+
 const walletSendCalls: RpcRequestInput = {
   method: 'wallet_sendCalls',
   params: [
@@ -43,4 +48,5 @@ export const walletTxMethods = [
   walletGetCallsStatus,
   walletShowCallsStatus,
   walletSendCalls,
+  walletGetUserInfo
 ];

--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
@@ -32,10 +32,11 @@ export function EIP1193ProviderContextProvider({ children }: EIP1193ProviderCont
   useEffect(() => {
     const sdkParams = {
       appName: 'SDK Playground',
-      appChainIds: [84532, 8452],
+      appChainIds: [1868, 1946],
       preference: {
         attribution: config.attribution,
         walletUrl: scwUrl ?? scwUrls[0],
+        telemetry: false
       },
       subAccounts: subAccountsConfig,
     };

--- a/examples/testapp/src/store/config.ts
+++ b/examples/testapp/src/store/config.ts
@@ -6,6 +6,7 @@ export type SDKVersionType = (typeof sdkVersions)[number];
 
 export const SELECTED_SCW_URL_KEY = 'scw_url';
 export const scwUrls = [
+    'https://keys.coinbase.com/connect',
     'http://localhost:3000/',
     'http://localhost:5174/',
 ] as const;

--- a/examples/testapp/src/store/config.ts
+++ b/examples/testapp/src/store/config.ts
@@ -6,8 +6,8 @@ export type SDKVersionType = (typeof sdkVersions)[number];
 
 export const SELECTED_SCW_URL_KEY = 'scw_url';
 export const scwUrls = [
-    'https://keys.coinbase.com/connect',
     'http://localhost:3000/',
     'http://localhost:5174/',
+    'https://keys.coinbase.com/connect',
 ] as const;
 export type ScwUrlType = (typeof scwUrls)[number];

--- a/packages/account-sdk/package.json
+++ b/packages/account-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@startale/superapp-sdk",
+  "name": "@base-org/account",
   "version": "2.0.2",
   "description": "Superapp SDK",
   "keywords": [

--- a/packages/account-sdk/src/core/rpc/wallet_connect.ts
+++ b/packages/account-sdk/src/core/rpc/wallet_connect.ts
@@ -66,4 +66,10 @@ export type WalletConnectResponse = {
       signInWithEthereum?: SignInWithEthereumCapabilityResponse | SerializedEthereumRpcError;
     };
   }[];
+  userInfo?: {
+    email?: string;
+    name?: string;
+    authType: string;
+    userId: string;
+  };
 };

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
@@ -85,7 +85,9 @@ export class BaseAccountProvider extends ProviderEventEmitter implements Provide
                   capabilities: {
                     ...(store.subAccountsConfig.get()?.capabilities ?? {}),
                   },
+                  ...args.params
                 },
+
               ],
             });
 

--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -363,6 +363,11 @@ export class Signer {
           accounts,
         });
 
+        const userInfo = response.userInfo;
+        store.userInfo.set({
+          ...userInfo
+        });
+        
         const account = response.accounts.at(0);
         const capabilities = account?.capabilities;
 
@@ -641,7 +646,7 @@ export class Signer {
     return response;
   }
 
-  private shouldRequestUseSubAccountSigner(request: RequestArguments) {
+  private shouldRequestUseSubAccountSigner(_request: RequestArguments) {
     return false
 
     // const sender = getSenderFromRequest(request);

--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -642,12 +642,14 @@ export class Signer {
   }
 
   private shouldRequestUseSubAccountSigner(request: RequestArguments) {
-    const sender = getSenderFromRequest(request);
-    const subAccount = store.subAccounts.get();
-    if (sender) {
-      return sender.toLowerCase() === subAccount?.address.toLowerCase();
-    }
-    return false;
+    return false
+
+    // const sender = getSenderFromRequest(request);
+    // const subAccount = store.subAccounts.get();
+    // if (sender) {
+    //   return sender.toLowerCase() === subAccount?.address.toLowerCase();
+    // }
+    // return false;
   }
 
   private async sendRequestToSubAccountSigner(request: RequestArguments) {

--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -366,9 +366,7 @@ export class Signer {
         });
 
         const userInfo = response.userInfo;
-        store.userInfo.set({
-          ...userInfo
-        });
+        store.userInfo.set(userInfo);
         
         const account = response.accounts.at(0);
         const capabilities = account?.capabilities;

--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -658,7 +658,10 @@ export class Signer {
   }
 
   private shouldRequestUseSubAccountSigner(_request: RequestArguments) {
+    // Always false since in our case sub accounts are smart accounts.
     return false
+
+    // Commented out in case we implement ERC-7895 in the future.
 
     // const sender = getSenderFromRequest(request);
     // const subAccount = store.subAccounts.get();

--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -231,6 +231,8 @@ export class Signer {
         return numberToHex(this.chain.id);
       case 'wallet_getCapabilities':
         return this.handleGetCapabilitiesRequest(request);
+      case 'wallet_getUserInfo':
+        return this.handleGetUserInfoRequest(request);
       case 'wallet_switchEthereumChain':
         return this.handleSwitchChainRequest(request);
       case 'eth_ecRecover':
@@ -495,6 +497,15 @@ export class Signer {
     );
 
     return filteredCapabilities;
+  }
+
+  private async handleGetUserInfoRequest(_request: RequestArguments) {
+    const userInfo = store.getState().userInfo;
+    if (!userInfo) {
+      throw standardErrors.provider.unauthorized('No user info found');
+    }
+    
+    return userInfo;
   }
 
   private async sendEncryptedRequest(request: RequestArguments): Promise<RPCResponseMessage> {

--- a/packages/account-sdk/src/store/store.ts
+++ b/packages/account-sdk/src/store/store.ts
@@ -48,6 +48,10 @@ type ChainSlice = {
   chains: Chain[];
 };
 
+type UserInfo = {
+  email?: string;
+};
+
 const createChainSlice: StateCreator<StoreState, [], [], ChainSlice> = () => {
   return {
     chains: [],
@@ -116,6 +120,16 @@ const createConfigSlice: StateCreator<StoreState, [], [], ConfigSlice> = () => {
   };
 };
 
+type UserInfoSlice = {
+  userInfo: UserInfo;
+};
+
+const createUserInfoSlice: StateCreator<StoreState, [], [], UserInfoSlice> = () => {
+  return {
+    userInfo: {},
+  };
+};
+
 type MergeTypes<T extends unknown[]> = T extends [infer First, ...infer Rest]
   ? First & (Rest extends unknown[] ? MergeTypes<Rest> : Record<string, unknown>)
   : Record<string, unknown>;
@@ -129,6 +143,7 @@ export type StoreState = MergeTypes<
     SubAccountConfigSlice,
     SpendPermissionsSlice,
     ConfigSlice,
+    UserInfoSlice,
   ]
 >;
 
@@ -142,6 +157,7 @@ export const sdkstore = createStore(
       ...createSpendPermissionsSlice(...args),
       ...createConfigSlice(...args),
       ...createSubAccountConfigSlice(...args),
+      ...createUserInfoSlice(...args),
     }),
     {
       name: 'base-acc-sdk.store',
@@ -156,6 +172,7 @@ export const sdkstore = createStore(
           subAccount: state.subAccount,
           spendPermissions: state.spendPermissions,
           config: state.config,
+          userInfo: state.userInfo,
         } as StoreState;
       },
     }
@@ -251,6 +268,20 @@ export const config = {
   },
 };
 
+export const userInfo = {
+  get: () => sdkstore.getState().userInfo,
+  set: (userInfo: Partial<UserInfo>) => {
+    sdkstore.setState((state) => ({
+      userInfo: { ...state.userInfo, ...userInfo },
+    }));
+  },
+  clear: () => {
+    sdkstore.setState({
+      userInfo: {},
+    });
+  },
+};
+
 const actions = {
   subAccounts,
   subAccountsConfig,
@@ -259,6 +290,7 @@ const actions = {
   chains,
   keys,
   config,
+  userInfo,
 };
 
 export const store = {

--- a/packages/account-sdk/src/store/store.ts
+++ b/packages/account-sdk/src/store/store.ts
@@ -273,9 +273,9 @@ export const config = {
 
 export const userInfo = {
   get: () => sdkstore.getState().userInfo,
-  set: (userInfo: Partial<UserInfo>) => {
-    sdkstore.setState((state) => ({
-      userInfo: { ...state.userInfo, ...userInfo },
+  set: (userInfo: Partial<UserInfo> | undefined) => {
+    sdkstore.setState((_state) => ({
+      userInfo
     }));
   },
   clear: () => {

--- a/packages/account-sdk/src/store/store.ts
+++ b/packages/account-sdk/src/store/store.ts
@@ -49,7 +49,10 @@ type ChainSlice = {
 };
 
 type UserInfo = {
-  email?: string;
+  userId?: string
+	email?: string
+	name?: string
+	authType?: string
 };
 
 const createChainSlice: StateCreator<StoreState, [], [], ChainSlice> = () => {

--- a/packages/account-sdk/src/util/web.ts
+++ b/packages/account-sdk/src/util/web.ts
@@ -45,7 +45,7 @@ export function openPopup(url: URL): Promise<Window> {
 
 export function closePopup(popup: Window | null) {
   if (popup && !popup.closed) {
-    // popup.close();
+    popup.close();
   }
 }
 

--- a/packages/account-sdk/src/util/web.ts
+++ b/packages/account-sdk/src/util/web.ts
@@ -45,7 +45,7 @@ export function openPopup(url: URL): Promise<Window> {
 
 export function closePopup(popup: Window | null) {
   if (popup && !popup.closed) {
-    popup.close();
+    // popup.close();
   }
 }
 


### PR DESCRIPTION
### _Summary_

- Added `authType` parameter to `eth_requestAccounts` method
- Added `wallet_getUserInfo` method to provide authenticated user details.
- Ignore current sub accounts logic since we are using smart account not ERC-7895 hierarchical accounts.

### _How did you test your changes?_

<img width="467" height="286" alt="image" src="https://github.com/user-attachments/assets/196e4588-605c-4c4f-b513-3c0254b864cc" />
<img width="948" height="522" alt="image" src="https://github.com/user-attachments/assets/38c7676b-345b-4a7e-970f-7c87e5b1344f" />

