### PR TITLE
[DO NOT MERGE] Support paid RPC through config

### DIFF
--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
@@ -7,6 +7,7 @@ import {
 	useMemo,
 	useState,
 } from 'react'
+import { soneium, soneiumMinato } from 'viem/chains'
 import { DisconnectedAlert } from '../components/alerts/DisconnectedAlert'
 import { useEventListeners } from '../hooks/useEventListeners'
 import { useSpyOnDisconnectedError } from '../hooks/useSpyOnDisconnectedError'
@@ -48,7 +49,7 @@ export function EIP1193ProviderContextProvider({
 		const sdkParams = {
 			appName: 'Startale app SDK Playground',
 			appLogoUrl: 'https://startale.com/image/symbol.png',
-			appChainIds: [1946, 1868],
+			appChainIds: [soneiumMinato.id, soneium.id],
 			preference: {
 				attribution: config.attribution,
 				walletUrl: scwUrl ?? scwUrls[0],
@@ -58,6 +59,10 @@ export function EIP1193ProviderContextProvider({
 			paymasterId,
 			paymasterApiKey,
 			bundlerApiKey,
+			rpcUrls: {
+				[soneium.id]: process.env.NEXT_PUBLIC_SONEIUM_RPC_URL,
+				[soneiumMinato.id]: process.env.NEXT_PUBLIC_MINATO_RPC_URL,
+			},
 		}
 
 		const sdk = createBaseAccountSDKHEAD(sdkParams)

--- a/examples/testapp/src/store/config.ts
+++ b/examples/testapp/src/store/config.ts
@@ -8,5 +8,6 @@ export const SELECTED_SCW_URL_KEY = 'scw_url'
 export const scwUrls = [
 	'https://deploy-sub-account-poc-for-yoake-sa-228.d3qb16qon2uoic.amplifyapp.com',
 	'http://localhost:3000/',
+  'https://keys.coinbase.com/connect'
 ] as const
 export type ScwUrlType = (typeof scwUrls)[number]

--- a/packages/app-sdk/src/core/provider/interface.ts
+++ b/packages/app-sdk/src/core/provider/interface.ts
@@ -112,4 +112,5 @@ export interface ConstructorOptions {
 	metadata: AppMetadata
 	preference: Preference
 	paymasterUrls?: Record<number, string>
+	rpcUrls?: Record<number, string>
 }

--- a/packages/app-sdk/src/interface/builder/core/createBaseAccountSDK.ts
+++ b/packages/app-sdk/src/interface/builder/core/createBaseAccountSDK.ts
@@ -24,6 +24,7 @@ export type CreateProviderOptions = Partial<AppMetadata> & {
 	preference?: Preference
 	subAccounts?: Omit<SubAccountOptions, 'enableAutoSubAccounts'>
 	paymasterUrls?: Record<number, string>
+	rpcUrls?: Record<number, string>
 }
 
 /**
@@ -40,6 +41,7 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
 		},
 		preference: params.preference ?? {},
 		paymasterUrls: params.paymasterUrls,
+		rpcUrls: params.rpcUrls,
 	}
 
 	//  ====================================================================

--- a/packages/app-sdk/src/sign/app-sdk/Signer.ts
+++ b/packages/app-sdk/src/sign/app-sdk/Signer.ts
@@ -49,7 +49,7 @@ import {
 	getClient,
 } from ':store/chain-clients/utils.js'
 import { correlationIds } from ':store/correlation-ids/store.js'
-import { spendPermissions, store } from ':store/store.js'
+import { config, spendPermissions, store } from ':store/store.js'
 import { assertArrayPresence, assertPresence } from ':util/assertPresence.js'
 import { assertSubAccount } from ':util/assertSubAccount.js'
 import {
@@ -621,12 +621,13 @@ export class Signer {
 		const availableChains = response.data?.chains
 		if (availableChains) {
 			const nativeCurrencies = response.data?.nativeCurrencies
+			const rpcUrls = config.get().rpcUrls
 			const chains: SDKChain[] = Object.entries(availableChains).map(
 				([id, rpcUrl]) => {
 					const nativeCurrency = nativeCurrencies?.[Number(id)]
 					return {
 						id: Number(id),
-						rpcUrl,
+						rpcUrl: rpcUrls?.[Number(id)] ?? rpcUrl,
 						...(nativeCurrency ? { nativeCurrency } : {}),
 					}
 				},

--- a/packages/app-sdk/src/store/store.ts
+++ b/packages/app-sdk/src/store/store.ts
@@ -46,6 +46,7 @@ type Config = {
 	version: string
 	deviceId?: string
 	paymasterUrls?: Record<number, string>
+	rpcUrls?: Record<number, string>
 }
 
 type ChainSlice = {
@@ -193,7 +194,7 @@ export const sdkstore = createStore(
 			...createUserInfoSlice(...args),
 		}),
 		{
-			name: 'base-acc-sdk.store',
+			name: 'startale-app-sdk.store',
 			storage: createJSONStorage(() => localStorage),
 			partialize: (state) => {
 				// Explicitly select only the data properties we want to persist


### PR DESCRIPTION
### _Summary_

I wanted to provide dApp developers with ability to provide custom RPC if they don't wan't to use public RPCs provided by Startale app.
In the process I figured out that there is no way to secure dApp secrets in the SDK. 

