### PR TITLE
wallet_getCapabilities params

### DIFF
--- a/examples/testapp/src/components/RpcMethods/method/walletTxMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/walletTxMethods.ts
@@ -3,7 +3,14 @@ import { RpcRequestInput } from './RpcRequestInput'
 
 const walletGetCapabilities: RpcRequestInput = {
 	method: 'wallet_getCapabilities',
-	params: [],
+	params: [
+		{key:'address', required: true},
+		{key:'chainIds', required: false},
+	],
+	format: (data: Record<string, any>) => [
+		data.address,
+		data.chainIds ? data.chainIds.split(/[\s,]+/) : []
+	]
 }
 
 const walletGetUserInfo: RpcRequestInput = {

--- a/examples/testapp/src/components/RpcMethods/shortcut/multipleChainShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/multipleChainShortcuts.ts
@@ -1,29 +1,29 @@
 import { mainnet, soneium, soneiumMinato } from 'viem/chains'
 
-import { ShortcutType } from './ShortcutType'
+import type { ShortcutType } from './ShortcutType'
 
 const walletSwitchEthereumChainShortcuts: ShortcutType[] = [
 	{
 		key: 'Soneium',
 		data: {
-			chainId: '1868',
+			chainId: soneium.id.toString(),
 			chain: soneium,
 		},
 	},
 	{
 		key: 'Minato',
 		data: {
-			chainId: '1946',
+			chainId: soneiumMinato.id.toString(),
 			chain: soneiumMinato,
 		},
 	},
-		{
+	{
 		key: 'Ethereum',
 		data: {
-			chainId: '1',
+			chainId: mainnet.id.toString(),
 			chain: mainnet,
 		},
-	}
+	},
 ]
 
 const walletAddEthereumChainShortcuts: ShortcutType[] = [

--- a/examples/testapp/src/components/RpcMethods/shortcut/multipleChainShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/multipleChainShortcuts.ts
@@ -1,4 +1,4 @@
-import { soneium, soneiumMinato } from 'viem/chains'
+import { mainnet, soneium, soneiumMinato } from 'viem/chains'
 
 import { ShortcutType } from './ShortcutType'
 
@@ -17,6 +17,13 @@ const walletSwitchEthereumChainShortcuts: ShortcutType[] = [
 			chain: soneiumMinato,
 		},
 	},
+		{
+		key: 'Ethereum',
+		data: {
+			chainId: '1',
+			chain: mainnet,
+		},
+	}
 ]
 
 const walletAddEthereumChainShortcuts: ShortcutType[] = [

--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
@@ -7,6 +7,7 @@ import {
 	useMemo,
 	useState,
 } from 'react'
+import { mainnet, soneium, soneiumMinato } from 'viem/chains'
 import { DisconnectedAlert } from '../components/alerts/DisconnectedAlert'
 import { useEventListeners } from '../hooks/useEventListeners'
 import { useSpyOnDisconnectedError } from '../hooks/useSpyOnDisconnectedError'
@@ -48,7 +49,7 @@ export function EIP1193ProviderContextProvider({
 		const sdkParams = {
 			appName: 'Startale app SDK Playground',
 			appLogoUrl: 'https://startale.com/image/symbol.png',
-			appChainIds: [1946, 1868],
+			appChainIds: [soneiumMinato.id, soneium.id, mainnet.id],
 			preference: {
 				attribution: config.attribution,
 				walletUrl: scwUrl ?? scwUrls[0],


### PR DESCRIPTION
### _Summary_
Added `address` and `chainIds` parameters to SDK test app. The command requires `address` while chain id array is optional.
Startale app, already sends wallet capabilities in [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities) format, so no changes required there.

Added ethereum network to SDK initialization for test purposes.

### _How did you test your changes?_
<img width="459" height="952" alt="image" src="https://github.com/user-attachments/assets/8e850a38-d68c-48b9-830d-69d3e4e0e5b4" />

`auxiliaryFunds` capability indicates if a smart contract wallet has access to funds beyond its on-chain balance, often used for paying gas fees through services like paymasters.
