### PR TITLE
Add Paymaster capabilitie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ examples/testapp/.next/
 /**/tsconfig.tsbuildinfo
 
 .editorconfig
+.env
 
 CLAUDE.md
 AGENTS.md

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Sync `base-master` locally from upstream (Base Account SDK)
 
 ```bash
-git remote add base https://github.com/base/account-sdk.git
+git remote add base https://github.com/StartaleGroup/app-sdk.git
 git fetch base
 git checkout base-master
 git pull base master

--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
@@ -56,9 +56,8 @@ export function EIP1193ProviderContextProvider({
 				telemetry: false,
 			},
 			subAccounts: subAccountsConfig,
-			paymasterId,
-			paymasterApiKey,
-			bundlerApiKey,
+			paymasterOptions: paymasterId && paymasterApiKey ? {
+				1868: { url: `https://paymaster.scs.startale.com/v1?apikey=${paymasterApiKey}`, id:paymasterId}} : undefined,
 		}
 
 		const sdk = createStartaleAccountSDKHEAD(sdkParams)

--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
@@ -57,7 +57,7 @@ export function EIP1193ProviderContextProvider({
 			},
 			subAccounts: subAccountsConfig,
 			paymasterOptions: paymasterId && paymasterApiKey ? {
-				1868: { url: `https://paymaster.scs.startale.com/v1?apikey=${paymasterApiKey}`, id:paymasterId}} : undefined,
+				1868: { url: `https://paymaster.scs.startale.com/v1?apikey=${paymasterApiKey}`, id: paymasterId}} : undefined,
 		}
 
 		const sdk = createStartaleAccountSDKHEAD(sdkParams)

--- a/packages/app-sdk/README.md
+++ b/packages/app-sdk/README.md
@@ -68,7 +68,7 @@
    });
    ```
 
-2. Make Base Account Provider
+2. Make Startale App Provider
 
    ```js
    const provider = sdk.getProvider();

--- a/packages/app-sdk/src/core/provider/interface.ts
+++ b/packages/app-sdk/src/core/provider/interface.ts
@@ -108,8 +108,13 @@ export type SubAccountOptions = {
 	unstable_enableAutoSpendPermissions?: boolean
 }
 
+export type PaymasterOptions = {
+	url: string
+	id:string
+}
+
 export interface ConstructorOptions {
 	metadata: AppMetadata
 	preference: Preference
-	paymasterUrls?: Record<number, string>
+	paymasterOptions?: Record<number, PaymasterOptions>
 }

--- a/packages/app-sdk/src/core/provider/interface.ts
+++ b/packages/app-sdk/src/core/provider/interface.ts
@@ -110,7 +110,7 @@ export type SubAccountOptions = {
 
 export type PaymasterOptions = {
 	url: string
-	id:string
+	id: string
 }
 
 export interface ConstructorOptions {

--- a/packages/app-sdk/src/interface/builder/core/createStartaleAccountSDK.test.ts
+++ b/packages/app-sdk/src/interface/builder/core/createStartaleAccountSDK.test.ts
@@ -130,8 +130,8 @@ describe('createProvider', () => {
 		it('should create a provider with paymaster options', () => {
 			const params: CreateProviderOptions = {
 				paymasterOptions: {
-					1: {url: 'https://paymaster.example.com', id: 'pm-1'},
-					137: {url: 'https://paymaster-polygon.example.com', id: 'pm-137'},
+					1: { url: 'https://paymaster.example.com', id: 'pm-1' },
+					137: { url: 'https://paymaster-polygon.example.com', id: 'pm-137' },
 				},
 			}
 
@@ -140,8 +140,8 @@ describe('createProvider', () => {
 			expect(mockBaseAccountProvider).toHaveBeenCalledWith(
 				expect.objectContaining({
 					paymasterOptions: {
-						1: {url: 'https://paymaster.example.com', id: 'pm-1'},
-						137: {url: 'https://paymaster-polygon.example.com', id: 'pm-137'},
+						1: { url: 'https://paymaster.example.com', id: 'pm-1' },
+						137: { url: 'https://paymaster-polygon.example.com', id: 'pm-137' },
 					},
 				}),
 			)
@@ -263,7 +263,7 @@ describe('createProvider', () => {
 			const params: CreateProviderOptions = {
 				appName: 'Test App',
 				preference: {},
-				paymasterOptions: { 1: {url: 'https://paymaster.example.com', id: 'pm-1'} },
+				paymasterOptions: { 1: { url: 'https://paymaster.example.com', id: 'pm-1' } },
 			}
 
 			createStartaleAccountSDK(params).getProvider()
@@ -275,7 +275,7 @@ describe('createProvider', () => {
 					appChainIds: [],
 				},
 				preference: {},
-				paymasterOptions: { 1: {url: 'https://paymaster.example.com', id: 'pm-1'} },
+				paymasterOptions: { 1: { url: 'https://paymaster.example.com', id: 'pm-1' } },
 			})
 		})
 
@@ -401,7 +401,7 @@ describe('createProvider', () => {
 					enableAutoSubAccounts: true,
 				},
 				paymasterOptions: {
-					1: {url: 'https://paymaster.example.com', id: 'pm-1'},
+					1: { url: 'https://paymaster.example.com', id: 'pm-1' },
 				},
 			}
 
@@ -426,7 +426,7 @@ describe('createProvider', () => {
 					telemetry: true,
 				},
 				paymasterOptions: {
-					1: {url: 'https://paymaster.example.com', id: 'pm-1'},
+					1: { url: 'https://paymaster.example.com', id: 'pm-1' },
 				},
 			})
 
@@ -453,7 +453,7 @@ describe('createProvider', () => {
 					telemetry: true,
 				},
 				paymasterOptions: {
-					1: {url: 'https://paymaster.example.com', id: 'pm-1'},
+					1: { url: 'https://paymaster.example.com', id: 'pm-1' },
 				},
 			})
 

--- a/packages/app-sdk/src/interface/builder/core/createStartaleAccountSDK.test.ts
+++ b/packages/app-sdk/src/interface/builder/core/createStartaleAccountSDK.test.ts
@@ -79,7 +79,7 @@ describe('createProvider', () => {
 					appChainIds: [],
 				},
 				preference: {},
-				paymasterUrls: undefined,
+				paymasterOptions: undefined,
 			})
 
 			expect(result).toEqual({ mockProvider: true })
@@ -101,7 +101,7 @@ describe('createProvider', () => {
 					appChainIds: [1, 137],
 				},
 				preference: {},
-				paymasterUrls: undefined,
+				paymasterOptions: undefined,
 			})
 		})
 
@@ -123,15 +123,15 @@ describe('createProvider', () => {
 				preference: {
 					attribution: { auto: true },
 				},
-				paymasterUrls: undefined,
+				paymasterOptions: undefined,
 			})
 		})
 
-		it('should create a provider with paymaster URLs', () => {
+		it('should create a provider with paymaster options', () => {
 			const params: CreateProviderOptions = {
-				paymasterUrls: {
-					1: 'https://paymaster.example.com',
-					137: 'https://paymaster-polygon.example.com',
+				paymasterOptions: {
+					1: {url: 'https://paymaster.example.com', id: 'pm-1'},
+					137: {url: 'https://paymaster-polygon.example.com', id: 'pm-137'},
 				},
 			}
 
@@ -139,9 +139,9 @@ describe('createProvider', () => {
 
 			expect(mockBaseAccountProvider).toHaveBeenCalledWith(
 				expect.objectContaining({
-					paymasterUrls: {
-						1: 'https://paymaster.example.com',
-						137: 'https://paymaster-polygon.example.com',
+					paymasterOptions: {
+						1: {url: 'https://paymaster.example.com', id: 'pm-1'},
+						137: {url: 'https://paymaster-polygon.example.com', id: 'pm-137'},
 					},
 				}),
 			)
@@ -263,7 +263,7 @@ describe('createProvider', () => {
 			const params: CreateProviderOptions = {
 				appName: 'Test App',
 				preference: {},
-				paymasterUrls: { 1: 'https://paymaster.example.com' },
+				paymasterOptions: { 1: {url: 'https://paymaster.example.com', id: 'pm-1'} },
 			}
 
 			createStartaleAccountSDK(params).getProvider()
@@ -275,7 +275,7 @@ describe('createProvider', () => {
 					appChainIds: [],
 				},
 				preference: {},
-				paymasterUrls: { 1: 'https://paymaster.example.com' },
+				paymasterOptions: { 1: {url: 'https://paymaster.example.com', id: 'pm-1'} },
 			})
 		})
 
@@ -379,7 +379,7 @@ describe('createProvider', () => {
 					appChainIds: [],
 				},
 				preference: {},
-				paymasterUrls: undefined,
+				paymasterOptions: undefined,
 			})
 			expect(result).toEqual({ mockProvider: true })
 		})
@@ -400,8 +400,8 @@ describe('createProvider', () => {
 					// @ts-expect-error - enableAutoSubAccounts is not officially supported yet
 					enableAutoSubAccounts: true,
 				},
-				paymasterUrls: {
-					1: 'https://paymaster.example.com',
+				paymasterOptions: {
+					1: {url: 'https://paymaster.example.com', id: 'pm-1'},
 				},
 			}
 
@@ -425,8 +425,8 @@ describe('createProvider', () => {
 				preference: {
 					telemetry: true,
 				},
-				paymasterUrls: {
-					1: 'https://paymaster.example.com',
+				paymasterOptions: {
+					1: {url: 'https://paymaster.example.com', id: 'pm-1'},
 				},
 			})
 
@@ -452,8 +452,8 @@ describe('createProvider', () => {
 				preference: {
 					telemetry: true,
 				},
-				paymasterUrls: {
-					1: 'https://paymaster.example.com',
+				paymasterOptions: {
+					1: {url: 'https://paymaster.example.com', id: 'pm-1'},
 				},
 			})
 

--- a/packages/app-sdk/src/interface/builder/core/createStartaleAccountSDK.ts
+++ b/packages/app-sdk/src/interface/builder/core/createStartaleAccountSDK.ts
@@ -1,9 +1,10 @@
 import {
 	AppMetadata,
 	ConstructorOptions,
+	PaymasterOptions,
 	Preference,
 	ProviderInterface,
-	SubAccountOptions,
+	SubAccountOptions
 } from ':core/provider/interface.js'
 import { AddSubAccountAccount } from ':core/rpc/wallet_addSubAccount.js'
 import { WalletConnectResponse } from ':core/rpc/wallet_connect.js'
@@ -23,7 +24,7 @@ import { getInjectedProvider } from './getInjectedProvider.js'
 export type CreateProviderOptions = Partial<AppMetadata> & {
 	preference?: Preference
 	subAccounts?: Omit<SubAccountOptions, 'enableAutoSubAccounts'>
-	paymasterUrls?: Record<number, string>
+	paymasterOptions?: Record<number, PaymasterOptions>
 }
 
 /**
@@ -39,7 +40,7 @@ export function createStartaleAccountSDK(params: CreateProviderOptions) {
 			appChainIds: params.appChainIds || [],
 		},
 		preference: params.preference ?? {},
-		paymasterUrls: params.paymasterUrls,
+		paymasterOptions: params.paymasterOptions,
 	}
 
 	//  ====================================================================

--- a/packages/app-sdk/src/sign/app-sdk/Signer.ts
+++ b/packages/app-sdk/src/sign/app-sdk/Signer.ts
@@ -62,6 +62,7 @@ import { fetchRPCRequest } from ':util/provider.js'
 import { getCryptoKeyAccount } from '../../kms/crypto-key/index.js'
 import { SCWKeyManager } from './SCWKeyManager.js'
 import {
+	addPaymasterToRequest,
 	addSenderToRequest,
 	appendWithoutDuplicates,
 	assertFetchPermissionsRequest,
@@ -369,10 +370,11 @@ export class Signer {
 		// This is to ensure that the popup is not blocked by some browsers (i.e. Safari)
 		await this.communicator.waitForPopupLoaded?.()
 
-		const response = await this.sendEncryptedRequest(request)
+		const requestWithPaymaster = addPaymasterToRequest(request, this.chain.id)
+		const response = await this.sendEncryptedRequest(requestWithPaymaster)
 		const decrypted = await this.decryptResponseMessage(response)
 
-		return this.handleResponse(request, decrypted)
+		return this.handleResponse(requestWithPaymaster, decrypted)
 	}
 
 	private async handleResponse(

--- a/packages/app-sdk/src/sign/app-sdk/utils.test.ts
+++ b/packages/app-sdk/src/sign/app-sdk/utils.test.ts
@@ -474,7 +474,7 @@ describe('createWalletSendCallsRequest', () => {
 			params: [
 				expect.objectContaining({
 					capabilities: {
-						paymasterService: { url: 'https://paymaster.example.com', id: 'pm-1'},
+						paymasterService: { url: 'https://paymaster.example.com', id: 'pm-1' },
 					},
 				}),
 			],

--- a/packages/app-sdk/src/sign/app-sdk/utils.test.ts
+++ b/packages/app-sdk/src/sign/app-sdk/utils.test.ts
@@ -448,11 +448,11 @@ describe('createSpendPermissionBatchMessage', () => {
 })
 
 describe('createWalletSendCallsRequest', () => {
-	it('should inject paymaster url if provided', () => {
+	it('should inject paymaster info if provided', () => {
 		// mock store config
 		vi.spyOn(store.config, 'get').mockReturnValue({
-			paymasterUrls: {
-				1: 'https://paymaster.example.com',
+			paymasterOptions: {
+				1: { url: 'https://paymaster.example.com', id: 'pm-1' },
 			},
 			version: '1.0.0',
 		})
@@ -474,7 +474,7 @@ describe('createWalletSendCallsRequest', () => {
 			params: [
 				expect.objectContaining({
 					capabilities: {
-						paymasterService: { url: 'https://paymaster.example.com' },
+						paymasterService: { url: 'https://paymaster.example.com', id: 'pm-1'},
 					},
 				}),
 			],

--- a/packages/app-sdk/src/sign/app-sdk/utils.test.ts
+++ b/packages/app-sdk/src/sign/app-sdk/utils.test.ts
@@ -1,6 +1,7 @@
-import { store } from ':store/store.js'
+import { config, store } from ':store/store.js'
 import { hashTypedData, hexToBigInt, numberToHex } from 'viem'
 import {
+	addPaymasterToRequest,
 	addSenderToRequest,
 	appendWithoutDuplicates,
 	assertFetchPermissionsRequest,
@@ -828,6 +829,466 @@ describe('getCachedWalletConnectResponse', () => {
 					},
 				},
 			],
+		})
+	})
+})
+
+describe('addPaymasterToRequest', () => {
+	const chainId = 1
+	const paymasterUrl = 'https://paymaster.example.com'
+	const paymasterId = 'test-paymaster-id'
+
+	beforeEach(() => {
+		vi.spyOn(config, 'get').mockReturnValue({
+			paymasterOptions: {},
+			version: '1.0.0',
+		} as any)
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	describe('non-wallet_sendCalls requests', () => {
+		it('should return request unchanged for eth_sendTransaction', () => {
+			const request = {
+				method: 'eth_sendTransaction',
+				params: [{ from: VALID_ADDRESS_1, to: VALID_ADDRESS_2, value: '0x0' }],
+			}
+
+			const result = addPaymasterToRequest(request, chainId)
+			expect(result).toEqual(request)
+		})
+
+		it('should return request unchanged for personal_sign', () => {
+			const request = {
+				method: 'personal_sign',
+				params: ['0xmessage', VALID_ADDRESS_1],
+			}
+
+			const result = addPaymasterToRequest(request, chainId)
+			expect(result).toEqual(request)
+		})
+
+		it('should return request unchanged for eth_signTypedData_v4', () => {
+			const request = {
+				method: 'eth_signTypedData_v4',
+				params: [VALID_ADDRESS_1, { some: 'data' }],
+			}
+
+			const result = addPaymasterToRequest(request, chainId)
+			expect(result).toEqual(request)
+		})
+
+		it('should return request unchanged for wallet_connect', () => {
+			const request = {
+				method: 'wallet_connect',
+				params: [{ chainId: '0x1' }],
+			}
+
+			const result = addPaymasterToRequest(request, chainId)
+			expect(result).toEqual(request)
+		})
+	})
+
+	describe('wallet_sendCalls requests - no paymaster options', () => {
+		it('should return request unchanged when no paymaster options are configured', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+			expect(result).toEqual(request)
+		})
+
+		it('should return request unchanged when paymasterOptions is undefined', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: undefined,
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+			expect(result).toEqual(request)
+		})
+
+		it('should return request unchanged when paymasterOptions for chainId is not configured', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					137: { url: 'https://paymaster-polygon.com', id: 'polygon-id' },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, 1)
+			expect(result).toEqual(request)
+		})
+	})
+
+	describe('wallet_sendCalls requests - with paymaster options', () => {
+		it('should add paymaster capability when paymaster options exist for chainId', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [
+							{
+								to: VALID_ADDRESS_2,
+								data: '0x',
+								value: '0x0',
+							},
+						],
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					[chainId]: { url: paymasterUrl, id: paymasterId },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+
+			expect(result.method).toBe('wallet_sendCalls')
+			expect((result.params[0] as any).capabilities).toBeDefined()
+			expect((result.params[0] as any).capabilities.paymasterService).toEqual({
+				url: paymasterUrl,
+				id: paymasterId,
+			})
+		})
+
+		it('should preserve existing capabilities when adding paymaster', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+						capabilities: {
+							someExisting: { capability: 'value' },
+						},
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					[chainId]: { url: paymasterUrl, id: paymasterId },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+
+			expect((result.params[0] as any).capabilities.someExisting).toEqual({
+				capability: 'value',
+			})
+			expect((result.params[0] as any).capabilities.paymasterService).toEqual({
+				url: paymasterUrl,
+				id: paymasterId,
+			})
+		})
+
+		it('should preserve existing paymasterService capability (not override)', () => {
+			const oldPaymasterUrl = 'https://old-paymaster.com'
+			const oldPaymasterId = 'old-id'
+
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+						capabilities: {
+							paymasterService: {
+								url: oldPaymasterUrl,
+								id: oldPaymasterId,
+							},
+						},
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					[chainId]: { url: paymasterUrl, id: paymasterId },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+
+			// Existing paymasterService takes precedence due to capability merge order
+			expect((result.params[0] as any).capabilities.paymasterService).toEqual({
+				url: oldPaymasterUrl,
+				id: oldPaymasterId,
+			})
+		})
+
+		it('should handle multiple chains with different paymaster options', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x89',
+						from: VALID_ADDRESS_1,
+						calls: [],
+					},
+				],
+			}
+
+			const polygonChainId = 137
+			const polygonPaymasterUrl = 'https://paymaster-polygon.com'
+			const polygonPaymasterId = 'polygon-id'
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					[chainId]: { url: paymasterUrl, id: paymasterId },
+					[polygonChainId]: {
+						url: polygonPaymasterUrl,
+						id: polygonPaymasterId,
+					},
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, polygonChainId)
+
+			expect((result.params[0] as any).capabilities.paymasterService).toEqual({
+				url: polygonPaymasterUrl,
+				id: polygonPaymasterId,
+			})
+		})
+
+		it('should create capabilities object if it does not exist', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					[chainId]: { url: paymasterUrl, id: paymasterId },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+
+			expect((result.params[0] as any).capabilities).toBeDefined()
+			expect((result.params[0] as any).capabilities.paymasterService).toEqual({
+				url: paymasterUrl,
+				id: paymasterId,
+			})
+		})
+
+		it('should preserve other request properties when adding paymaster', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [
+							{
+								to: VALID_ADDRESS_2,
+								data: '0xdeadbeef',
+								value: '0x100',
+							},
+						],
+						atomicRequired: true,
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					[chainId]: { url: paymasterUrl, id: paymasterId },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+
+			expect((result.params[0] as any).version).toBe('1.0')
+			expect((result.params[0] as any).chainId).toBe('0x1')
+			expect((result.params[0] as any).from).toBe(VALID_ADDRESS_1)
+			expect((result.params[0] as any).calls).toEqual([
+				{
+					to: VALID_ADDRESS_2,
+					data: '0xdeadbeef',
+					value: '0x100',
+				},
+			])
+			expect((result.params[0] as any).atomicRequired).toBe(true)
+		})
+
+		it('should maintain request type identity', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					[chainId]: { url: paymasterUrl, id: paymasterId },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+
+			expect(result.method).toBe(request.method)
+			expect(typeof result.params).toBe(typeof request.params)
+		})
+
+		it('should handle chainId as string representation', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					1: { url: paymasterUrl, id: paymasterId },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, 1)
+
+			expect((result.params[0] as any).capabilities.paymasterService).toEqual({
+				url: paymasterUrl,
+				id: paymasterId,
+			})
+		})
+	})
+
+	describe('edge cases', () => {
+		it('should handle empty calls array', () => {
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					[chainId]: { url: paymasterUrl, id: paymasterId },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+
+			expect((result.params[0] as any).calls).toEqual([])
+			expect((result.params[0] as any).capabilities.paymasterService).toEqual({
+				url: paymasterUrl,
+				id: paymasterId,
+			})
+		})
+
+		it('should handle paymaster URL with query parameters', () => {
+			const urlWithParams = 'https://paymaster.example.com?key=value&foo=bar'
+
+			const request = {
+				method: 'wallet_sendCalls',
+				params: [
+					{
+						version: '1.0',
+						chainId: '0x1',
+						from: VALID_ADDRESS_1,
+						calls: [],
+					},
+				],
+			}
+
+			vi.mocked(config.get).mockReturnValue({
+				paymasterOptions: {
+					[chainId]: { url: urlWithParams, id: paymasterId },
+				},
+				version: '1.0.0',
+			} as any)
+
+			const result = addPaymasterToRequest(request, chainId)
+
+			expect((result.params[0] as any).capabilities.paymasterService.url).toBe(
+				urlWithParams,
+			)
 		})
 	})
 })

--- a/packages/app-sdk/src/sign/app-sdk/utils.ts
+++ b/packages/app-sdk/src/sign/app-sdk/utils.ts
@@ -648,15 +648,15 @@ export function addPaymasterToRequest<T extends RequestArguments>(
 	}
 
 	const paymasterOptions = config.get().paymasterOptions
-	const paymasterForChain = paymasterOptions?.[chainId]
-	if (!paymasterForChain) {
+	const optionsForChain = paymasterOptions?.[chainId]
+	if (!optionsForChain) {
 		return request
 	}
 
 	return injectRequestCapabilities(request, {
 		paymasterService: {
-			url: paymasterForChain.url,
-			id: paymasterForChain.id,
+			url: optionsForChain.url,
+			id: optionsForChain.id,
 		},
 	})
 }

--- a/packages/app-sdk/src/sign/app-sdk/utils.ts
+++ b/packages/app-sdk/src/sign/app-sdk/utils.ts
@@ -643,7 +643,7 @@ export function addPaymasterToRequest<T extends RequestArguments>(
 	request: T,
 	chainId: number,
 ): T {
-	if(request.method !== 'wallet_sendCalls')	 {
+	if (request.method !== 'wallet_sendCalls') {
 		return request
 	}
 

--- a/packages/app-sdk/src/sign/app-sdk/utils.ts
+++ b/packages/app-sdk/src/sign/app-sdk/utils.ts
@@ -413,7 +413,7 @@ export function createWalletSendCallsRequest({
 	chainId: number
 	capabilities?: Record<string, unknown>
 }) {
-	const paymasterUrls = config.get().paymasterUrls
+	const paymasterOptions = config.get().paymasterOptions
 
 	let request: {
 		method: 'wallet_sendCalls'
@@ -432,9 +432,9 @@ export function createWalletSendCallsRequest({
 		],
 	}
 
-	if (paymasterUrls?.[chainId]) {
+	if (paymasterOptions?.[chainId]) {
 		request = injectRequestCapabilities(request, {
-			paymasterService: { url: paymasterUrls?.[chainId] },
+			paymasterService: { url: paymasterOptions?.[chainId].url, id: paymasterOptions?.[chainId].id },
 		})
 	}
 

--- a/packages/app-sdk/src/sign/app-sdk/utils.ts
+++ b/packages/app-sdk/src/sign/app-sdk/utils.ts
@@ -638,3 +638,25 @@ export async function getCachedWalletConnectResponse(): Promise<WalletConnectRes
 		accounts: walletConnectAccounts,
 	}
 }
+
+export function addPaymasterToRequest<T extends RequestArguments>(
+	request: T,
+	chainId: number,
+): T {
+	if(request.method !== 'wallet_sendCalls')	 {
+		return request
+	}
+
+	const paymasterOptions = config.get().paymasterOptions
+	const paymasterForChain = paymasterOptions?.[chainId]
+	if (!paymasterForChain) {
+		return request
+	}
+
+	return injectRequestCapabilities(request, {
+		paymasterService: {
+			url: paymasterForChain.url,
+			id: paymasterForChain.id,
+		},
+	})
+}

--- a/packages/app-sdk/src/sign/app-sdk/utils.ts
+++ b/packages/app-sdk/src/sign/app-sdk/utils.ts
@@ -639,6 +639,11 @@ export async function getCachedWalletConnectResponse(): Promise<WalletConnectRes
 	}
 }
 
+/** Adds paymaster service information to a wallet_sendCalls request if configured for the given chainId
+ * @param request The original request object
+ * @param chainId The chain ID to check for paymaster configuration
+ * @returns The modified request object with paymaster information if applicable
+ */
 export function addPaymasterToRequest<T extends RequestArguments>(
 	request: T,
 	chainId: number,

--- a/packages/app-sdk/src/store/store.ts
+++ b/packages/app-sdk/src/store/store.ts
@@ -1,8 +1,9 @@
 import { PACKAGE_VERSION } from ':core/constants.js'
 import {
 	AppMetadata,
+	PaymasterOptions,
 	Preference,
-	SubAccountOptions,
+	SubAccountOptions
 } from ':core/provider/interface.js'
 import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js'
 import { OwnerAccount } from ':core/type/index.js'
@@ -45,7 +46,7 @@ type Config = {
 	preference?: Preference
 	version: string
 	deviceId?: string
-	paymasterUrls?: Record<number, string>
+	paymasterOptions?: Record<number, PaymasterOptions>
 }
 
 type ChainSlice = {


### PR DESCRIPTION
### _Summary_

This PR contains logic for adding paymaster capabilities to `wallet_sendCalls` request
[EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_sendcalls-rpc-specification) enables adding metadata to `capabilities` field of an request.

EIP-1193 RPC methods like: `eth_sendTransaction, personal_sign, eth_signTypedData_v4`, have fixed parameter structures defined by the Ethereum spec and cannot accept a capabilities object. I assume we would like to add paymaster capabilities to `eth_sendTransaction` which means we will need to wrap the call into `wallet_sendCalls`.
