### PR TITLE
EOA auth only

### DIFF
--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
@@ -54,6 +54,8 @@ export function EIP1193ProviderContextProvider({
 				attribution: config.attribution,
 				walletUrl: scwUrl ?? scwUrls[0],
 				telemetry: false,
+				eoaAuthOnly: false,
+				authType: undefined,
 			},
 			subAccounts: subAccountsConfig,
 			paymasterOptions: paymasterId && paymasterApiKey ? {

--- a/packages/app-sdk/src/core/provider/interface.ts
+++ b/packages/app-sdk/src/core/provider/interface.ts
@@ -91,6 +91,15 @@ export type Preference = {
 	 * @default true
 	 */
 	telemetry?: boolean
+	/** EOA authentication type
+	 * @description Specifies the type of authentication to be initiated by Startale app.
+	 * Supported values are 'google', 'line', and 'apple'.
+	 */
+	authType?: 'google' | 'line' | 'apple'
+	/** EOA authentication only
+	 * @description When set to true, only EOA authentication will be used, disabling other authentication methods.
+	 */
+	eoaAuthOnly?: boolean
 } & Record<string, unknown>
 
 export type SubAccountOptions = {

--- a/packages/app-sdk/src/core/provider/interface.ts
+++ b/packages/app-sdk/src/core/provider/interface.ts
@@ -94,10 +94,12 @@ export type Preference = {
 	/** EOA authentication type
 	 * @description Specifies the type of authentication to be initiated by Startale app.
 	 * Supported values are 'google', 'line', and 'apple'.
+	 * @default undefined
 	 */
 	authType?: 'google' | 'line' | 'apple'
 	/** EOA authentication only
 	 * @description When set to true, only EOA authentication will be used, disabling other authentication methods.
+	 * @default false - when not set, other authentication methods remain available.
 	 */
 	eoaAuthOnly?: boolean
 } & Record<string, unknown>

--- a/packages/app-sdk/src/store/store.ts
+++ b/packages/app-sdk/src/store/store.ts
@@ -194,7 +194,7 @@ export const sdkstore = createStore(
 			...createUserInfoSlice(...args),
 		}),
 		{
-			name: 'base-acc-sdk.store',
+			name: 'startale-app-sdk.store',
 			storage: createJSONStorage(() => localStorage),
 			partialize: (state) => {
 				// Explicitly select only the data properties we want to persist


### PR DESCRIPTION
### _Summary_

There is an requirement that in Soneium Score integration, only EOA authentication is allowed.

- add `eoaAuthOnly` and  `authType` to settings. The reason I added both params to settings is that they can be configured them during a dApp initialization if Wagmi or Rainbow kit are used
- rename SDK store key
