### PR TITLE
fix: clone superapp in setup action

### DIFF
--- a/.github/actions/prepare-superapp/action.yaml
+++ b/.github/actions/prepare-superapp/action.yaml
@@ -1,0 +1,75 @@
+name: Prepare SuperApp
+description: Clone and install SuperApp dependencies for E2E testing. Upload as artifact for reuse across jobs.
+
+inputs:
+  branch:
+    description: SuperApp branch to checkout
+    required: true
+  github-token:
+    description: GitHub token with read access to the SuperApp repo
+    required: true
+  app-env-content:
+    description: Content of the SuperApp .env file
+    required: true
+  npm-token:
+    description: NPM token for private packages
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        APP_ENV_CONTENT: ${{ inputs.app-env-content }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
+      run: |
+        missing=()
+        [ -z "$GH_TOKEN" ] && missing+=("github-token")
+        [ -z "$APP_ENV_CONTENT" ] && missing+=("app-env-content")
+        [ -z "$NPM_TOKEN" ] && missing+=("npm-token")
+        if [ ${#missing[@]} -gt 0 ]; then
+          echo "::error::Missing required inputs: ${missing[*]}"
+          exit 1
+        fi
+
+    - name: Clone SuperApp
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        SUPERAPP_BRANCH: ${{ inputs.branch }}
+      run: |
+        git clone --depth 1 --branch "${SUPERAPP_BRANCH}" \
+          "https://x-access-token:${GH_TOKEN}@github.com/StartaleGroup/superapp.git" \
+          /tmp/superapp
+
+    - name: Setup Node.js for SuperApp
+      uses: actions/setup-node@v4
+      with:
+        node-version: 24
+
+    - name: Setup pnpm for SuperApp
+      uses: pnpm/action-setup@v4
+      with:
+        run_install: false
+
+    - name: Create SuperApp .env
+      shell: bash
+      env:
+        APP_ENV_CONTENT: ${{ inputs.app-env-content }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
+      run: |
+        printf '%s\n' "$APP_ENV_CONTENT" > /tmp/superapp/app/.env
+        echo "NPM_TOKEN=${NPM_TOKEN}" >> /tmp/superapp/app/.env
+        echo ".env created ($(wc -l < /tmp/superapp/app/.env) lines)"
+
+    - name: Install SuperApp dependencies
+      shell: bash
+      working-directory: /tmp/superapp
+      env:
+        NPM_TOKEN: ${{ inputs.npm-token }}
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+        pnpm install --frozen-lockfile
+        rm -f .npmrc

--- a/.github/actions/start-superapp/action.yaml
+++ b/.github/actions/start-superapp/action.yaml
@@ -1,79 +1,9 @@
 name: Start SuperApp
-description: Clone, build, and serve SuperApp on localhost:3000 for E2E testing.
-
-inputs:
-  branch:
-    description: SuperApp branch to checkout
-    required: true
-  github-token:
-    description: GitHub token with read access to the SuperApp repo
-    required: true
-  app-env-content:
-    description: Content of the SuperApp .env file
-    required: true
-  npm-token:
-    description: NPM token for private packages
-    required: true
+description: Start SuperApp dev server from a pre-installed artifact on localhost:3000 for E2E testing.
 
 runs:
   using: composite
   steps:
-    - name: Validate inputs
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
-        APP_ENV_CONTENT: ${{ inputs.app-env-content }}
-        NPM_TOKEN: ${{ inputs.npm-token }}
-      run: |
-        missing=()
-        [ -z "$GH_TOKEN" ] && missing+=("github-token")
-        [ -z "$APP_ENV_CONTENT" ] && missing+=("app-env-content")
-        [ -z "$NPM_TOKEN" ] && missing+=("npm-token")
-        if [ ${#missing[@]} -gt 0 ]; then
-          echo "::error::Missing required inputs: ${missing[*]}"
-          exit 1
-        fi
-
-    - name: Clone SuperApp
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
-        SUPERAPP_BRANCH: ${{ inputs.branch }}
-      run: |
-        git clone --depth 1 --branch "${SUPERAPP_BRANCH}" \
-          "https://x-access-token:${GH_TOKEN}@github.com/StartaleGroup/superapp.git" \
-          /tmp/superapp
-
-    - name: Setup Node.js for SuperApp
-      uses: actions/setup-node@v4
-      with:
-        node-version: 24
-
-    - name: Setup pnpm for SuperApp
-      uses: pnpm/action-setup@v4
-      with:
-        run_install: false
-
-    - name: Create SuperApp .env
-      shell: bash
-      env:
-        APP_ENV_CONTENT: ${{ inputs.app-env-content }}
-        NPM_TOKEN: ${{ inputs.npm-token }}
-      run: |
-        printf '%s\n' "$APP_ENV_CONTENT" > /tmp/superapp/app/.env
-        echo "NPM_TOKEN=${NPM_TOKEN}" >> /tmp/superapp/app/.env
-        echo ".env created ($(wc -l < /tmp/superapp/app/.env) lines)"
-
-    - name: Install SuperApp dependencies
-      shell: bash
-      working-directory: /tmp/superapp
-      env:
-        NPM_TOKEN: ${{ inputs.npm-token }}
-      run: |
-        echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-        pnpm install --frozen-lockfile
-        rm -f .npmrc
-
     - name: Start SuperApp dev server
       shell: bash
       working-directory: /tmp/superapp

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -64,6 +64,23 @@ jobs:
           path: packages/*/dist/
           retention-days: 1
 
+      - name: Prepare SuperApp
+        if: inputs.superapp-branch != ''
+        uses: ./.github/actions/prepare-superapp
+        with:
+          branch: ${{ inputs.superapp-branch }}
+          github-token: ${{ secrets.SUPERAPP_GITHUB_TOKEN }}
+          app-env-content: ${{ secrets.APP_ENV_FILE }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Upload SuperApp
+        if: inputs.superapp-branch != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: superapp-ready
+          path: /tmp/superapp/
+          retention-days: 1
+
   smoke:
     needs: setup
     runs-on: ubuntu-latest
@@ -81,14 +98,16 @@ jobs:
 
       - uses: ./.github/actions/e2e-setup
 
+      - name: Download SuperApp
+        if: inputs.superapp-branch != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: superapp-ready
+          path: /tmp/superapp/
+
       - name: Start SuperApp
         if: inputs.superapp-branch != ''
         uses: ./.github/actions/start-superapp
-        with:
-          branch: ${{ inputs.superapp-branch }}
-          github-token: ${{ secrets.SUPERAPP_GITHUB_TOKEN }}
-          app-env-content: ${{ secrets.APP_ENV_FILE }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -136,14 +155,16 @@ jobs:
         with:
           install-chrome: 'true'
 
+      - name: Download SuperApp
+        if: inputs.superapp-branch != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: superapp-ready
+          path: /tmp/superapp/
+
       - name: Start SuperApp
         if: inputs.superapp-branch != ''
         uses: ./.github/actions/start-superapp
-        with:
-          branch: ${{ inputs.superapp-branch }}
-          github-token: ${{ secrets.SUPERAPP_GITHUB_TOKEN }}
-          app-env-content: ${{ secrets.APP_ENV_FILE }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -187,14 +208,16 @@ jobs:
 
       - uses: ./.github/actions/e2e-setup
 
+      - name: Download SuperApp
+        if: inputs.superapp-branch != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: superapp-ready
+          path: /tmp/superapp/
+
       - name: Start SuperApp
         if: inputs.superapp-branch != ''
         uses: ./.github/actions/start-superapp
-        with:
-          branch: ${{ inputs.superapp-branch }}
-          github-token: ${{ secrets.SUPERAPP_GITHUB_TOKEN }}
-          app-env-content: ${{ secrets.APP_ENV_FILE }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The previous CI settings worked on SuperApp's PR, but it clones SuperApp in each action. This PR fixes the issue by cloning the repo in the setup action only.