### PR TITLE
feat: added session storage for E2E test

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -17,6 +17,8 @@ on:
         required: true
       GOOGLE_TOTP_SECRET:
         required: true
+      GOOGLE_SESSION_STATE:
+        required: false
       WALLET_SEED:
         required: true
       SUPERAPP_GITHUB_TOKEN:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -135,6 +135,7 @@ jobs:
       GOOGLE_TEST_EMAIL: ${{ secrets.GOOGLE_TEST_EMAIL }}
       GOOGLE_TEST_PASSWORD: ${{ secrets.GOOGLE_TEST_PASSWORD }}
       GOOGLE_TOTP_SECRET: ${{ secrets.GOOGLE_TOTP_SECRET }}
+      GOOGLE_SESSION_STATE: ${{ secrets.GOOGLE_SESSION_STATE }}
     steps:
       - uses: actions/checkout@v4
         if: inputs.superapp-branch != ''

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ report/
 /references
 .playwright-mcp/
 .mcp.json
+docs/
+google-session.json

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -35,7 +35,45 @@ Copy `.env.example` to `.env` and fill in:
 | `GOOGLE_TEST_PASSWORD` | Yes (Google) | Google test account password |
 | `GOOGLE_TOTP_SECRET` | No | Base32 TOTP secret for 2FA |
 | `WALLET_SEED` | Yes (EOA) | MetaMask seed phrase for EOA tests |
+| `GOOGLE_SESSION_STATE` | No | Google session cookies JSON (see below) |
 | `SKIP_GOOGLE_OAUTH` | No | Set `true` to skip Google tests |
+
+### Google Session State (`GOOGLE_SESSION_STATE`)
+
+Google blocks automated sign-ins from unknown IPs by showing a "Verify it's you" challenge (SMS/phone verification instead of TOTP). Since GitHub Actions runners use different IPs on every run, CI tests fail consistently.
+
+`GOOGLE_SESSION_STATE` injects Google's authentication cookies (SID, HSID, etc.) into the browser context. Google recognizes these cookies and skips the "Verify it's you" challenge, allowing the normal TOTP-based login to proceed.
+
+**How it works:**
+- When set: Google auto-authenticates via cookies → login form is skipped entirely
+- When not set: Normal login flow runs (email → password → TOTP)
+
+**Generating the session:**
+
+```bash
+# 1. Start the testapp
+cd examples/testapp && pnpm dev
+
+# 2. Run the session save script (opens a browser for manual login)
+cd e2e && pnpm save:google-session
+
+# 3. Filter to Google cookies only and copy to clipboard
+cat google-session.json | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+filtered = {'cookies': [c for c in d['cookies'] if c.get('domain','').endswith('google.com') or c.get('domain','').endswith('google.com.sg')], 'origins': []}
+print(json.dumps(filtered))
+" | pbcopy
+```
+
+**For CI:** Paste the filtered JSON into GitHub Secret `GOOGLE_SESSION_STATE`.
+
+**For local testing:** Add to `e2e/.env`:
+```
+GOOGLE_SESSION_STATE=<filtered JSON>
+```
+
+> **Note:** Google session cookies will be expired some times in the future. Re-run `save:google-session` if tests start failing with "Verify it's you" again.
 
 ## Test Inventory
 

--- a/e2e/lib/auth/google-oauth.ts
+++ b/e2e/lib/auth/google-oauth.ts
@@ -44,31 +44,14 @@ const handle2FA = async (page: Page): Promise<void> => {
 }
 
 /**
- * Login with Google OAuth via the SDK popup.
- *
- * Flow:
- * 1. Click Google sign-in button in SDK popup
- * 2. Handle Google OAuth form (email, password, 2FA)
- * 3. Wait for redirect back to SCW (app.startale.com or localhost)
+ * Complete the Google OAuth email → password → 2FA form.
+ * Called only when Google shows the login form (no pre-existing session cookies).
  */
-export const loginWithGoogle = async (sdkPopup: Page): Promise<void> => {
-	const email = process.env.GOOGLE_TEST_EMAIL
-	const password = process.env.GOOGLE_TEST_PASSWORD
-
-	if (!email || !password) {
-		throw new Error(
-			'GOOGLE_TEST_EMAIL and GOOGLE_TEST_PASSWORD env vars required',
-		)
-	}
-
-	// Click "Log in with Google"
-	await sdkPopup
-		.getByRole('button', { name: 'Log in with Google' })
-		.click()
-
-	// Wait for Google OAuth page to load
-	await sdkPopup.waitForURL('**/accounts.google.com/**')
-
+const completeGoogleOAuthForm = async (
+	sdkPopup: Page,
+	email: string,
+	password: string,
+): Promise<void> => {
 	// type() with delay simulates human-like keystroke timing (100ms per char)
 	// to avoid Google's bot detection. fill() sets the value instantly and is
 	// more likely to be flagged as automated input.
@@ -88,12 +71,56 @@ export const loginWithGoogle = async (sdkPopup: Page): Promise<void> => {
 	if (process.env.GOOGLE_TOTP_SECRET) {
 		await handle2FA(sdkPopup)
 	}
+}
 
-	// Wait for redirect back to SCW (connect-wallet approval page).
-	// Use origin (scheme + host + port) so the pattern works for both
-	// production (https://app.startale.com) and localhost (http://localhost:3000).
+/**
+ * Login with Google OAuth via the SDK popup.
+ *
+ * Flow:
+ * 1. Click Google sign-in button in SDK popup
+ * 2. Handle Google OAuth form (email, password, 2FA) — OR skip if
+ *    Google auto-authenticates via pre-loaded session cookies
+ * 3. Wait for redirect back to SCW (app.startale.com or localhost)
+ * 4. Click "Approve" on the connect-wallet permission screen
+ */
+export const loginWithGoogle = async (sdkPopup: Page): Promise<void> => {
+	const email = process.env.GOOGLE_TEST_EMAIL
+	const password = process.env.GOOGLE_TEST_PASSWORD
+
+	if (!email || !password) {
+		throw new Error(
+			'GOOGLE_TEST_EMAIL and GOOGLE_TEST_PASSWORD env vars required',
+		)
+	}
+
 	const scwOrigin = new URL(SCW_URL).origin
-	await sdkPopup.waitForURL(`${scwOrigin}/**`)
+
+	// Click the Google sign-in button. The button text varies by page:
+	// - Login page: "Log in with Google"
+	// - Sign up page: "Google"
+	const googleButton = sdkPopup
+		.getByRole('button', { name: 'Log in with Google' })
+		.or(sdkPopup.getByRole('button', { name: 'Google' }))
+	await googleButton.click()
+
+	// After clicking Google, the popup navigates to accounts.google.com.
+	// If session cookies are present (GOOGLE_SESSION_STATE), Google may
+	// auto-authenticate and redirect back to SCW so fast that we never
+	// see accounts.google.com as the current URL. Race both possibilities.
+	const emailInput = sdkPopup.locator('input[type="email"]')
+	const needsManualLogin = await Promise.race([
+		emailInput
+			.waitFor({ state: 'visible', timeout: 30_000 })
+			.then(() => true),
+		sdkPopup
+			.waitForURL(`${scwOrigin}/**`, { timeout: 30_000 })
+			.then(() => false),
+	])
+
+	if (needsManualLogin) {
+		await completeGoogleOAuthForm(sdkPopup, email, password)
+		await sdkPopup.waitForURL(`${scwOrigin}/**`)
+	}
 
 	// Click the "Approve" button on the connect-wallet permission screen
 	const approveButton = sdkPopup.getByRole('button', { name: 'Approve' })

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -21,6 +21,7 @@
 		"test:ci:google": "playwright test --project=google-chromium",
 		"test:ci:eoa": "playwright test --project=eoa-chromium",
 		"install:playwright": "playwright install --with-deps",
-		"install:chrome": "playwright install chrome"
+		"install:chrome": "playwright install chrome",
+		"save:google-session": "npx tsx scripts/save-google-session.ts"
 	}
 }

--- a/e2e/scripts/save-google-session.ts
+++ b/e2e/scripts/save-google-session.ts
@@ -1,0 +1,80 @@
+/**
+ * Save Google OAuth session for CI E2E tests.
+ *
+ * This script opens a browser, navigates to the testapp, triggers
+ * the SDK popup, and waits for you to manually log in with Google.
+ * After login completes (popup closes), it saves the browser's
+ * storageState (cookies + localStorage) to google-session.json.
+ *
+ * The saved session contains Google's authentication cookies
+ * (SID, HSID, etc.) which prevent the "Verify it's you" challenge
+ * when running tests from CI's different IP addresses.
+ *
+ * Prerequisites:
+ *   - testapp running at http://localhost:3001 (cd examples/testapp && pnpm dev)
+ *
+ * Usage:
+ *   pnpm save:google-session
+ */
+import { chromium } from '@playwright/test'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { BASE_URL, ROUTES } from '../lib/constants.js'
+import { injectSCWUrl, waitForPopup } from '../lib/helpers.js'
+import { dashboardPage } from '../page-objects/dashboardPage.js'
+import { rpcMethodCard } from '../page-objects/rpcMethodCard.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const OUTPUT_PATH = resolve(__dirname, '..', 'google-session.json')
+
+const saveGoogleSession = async () => {
+	console.log('Launching browser...')
+
+	const browser = await chromium.launch({
+		headless: false,
+		args: ['--disable-blink-features=AutomationControlled'],
+	})
+	const context = await browser.newContext({ baseURL: BASE_URL })
+	const page = await context.newPage()
+
+	await injectSCWUrl(page)
+	await page.goto(ROUTES.dashboard)
+
+	const dashboard = dashboardPage(page)
+	await dashboard.verifyLoaded()
+
+	console.log('Opening SDK popup...')
+	const ethRequestAccounts = rpcMethodCard(page, 'eth_requestAccounts')
+	const sdkPopup = await waitForPopup(page, () =>
+		ethRequestAccounts.submit(),
+	)
+
+	console.log('')
+	console.log('=== Manual Login Required ===')
+	console.log('1. Log in with Google in the popup window')
+	console.log('2. Complete any verification (2FA, "Verify it\'s you", etc.)')
+	console.log('3. Click "Approve" on the connect-wallet screen')
+	console.log('The script will save the session automatically when the popup closes.')
+	console.log('')
+
+	// 5 minutes to allow manual login + 2FA + verification
+	await sdkPopup.waitForEvent('close', { timeout: 5 * 60 * 1000 })
+
+	console.log('Login complete. Saving session...')
+	await context.storageState({ path: OUTPUT_PATH })
+
+	await browser.close()
+
+	console.log(`Session saved to: ${OUTPUT_PATH}`)
+	console.log('')
+	console.log('Next steps:')
+	console.log('  1. Test locally:')
+	console.log('     GOOGLE_SESSION_STATE=$(cat e2e/google-session.json) pnpm test:google')
+	console.log('  2. For CI, copy the JSON content to GitHub Secret GOOGLE_SESSION_STATE')
+}
+
+saveGoogleSession().catch((error) => {
+	console.error('Failed to save session:', error)
+	process.exit(1)
+})

--- a/e2e/tests/google/rpc-methods.spec.ts
+++ b/e2e/tests/google/rpc-methods.spec.ts
@@ -41,11 +41,16 @@ test.describe('Google OAuth — RPC Methods', () => {
 		// Keep only Google cookies to bypass "Verify it's you" challenge.
 		// Exclude all other cookies (SCW, Dynamic Auth, privy) so the
 		// normal login flow runs from a clean state.
+		const isGoogleDomain = (domain: string) =>
+			domain === 'google.com' ||
+			domain.endsWith('.google.com') ||
+			domain === 'accounts.google.com' ||
+			domain.endsWith('.google.com.sg')
+
 		const storageState = googleSession
 			? {
 					cookies: googleSession.cookies.filter(
-						(c: { domain: string }) =>
-							c.domain.includes('google.com'),
+						(c: { domain: string }) => isGoogleDomain(c.domain),
 					),
 					origins: [],
 				}

--- a/e2e/tests/google/rpc-methods.spec.ts
+++ b/e2e/tests/google/rpc-methods.spec.ts
@@ -34,7 +34,23 @@ test.describe('Google OAuth — RPC Methods', () => {
 	let page: Page
 
 	test.beforeAll(async ({ browser, baseURL }) => {
-		context = await browser.newContext({ baseURL })
+		const googleSession = process.env.GOOGLE_SESSION_STATE
+			? JSON.parse(process.env.GOOGLE_SESSION_STATE)
+			: undefined
+
+		// Keep only Google cookies to bypass "Verify it's you" challenge.
+		// Exclude all other cookies (SCW, Dynamic Auth, privy) so the
+		// normal login flow runs from a clean state.
+		const storageState = googleSession
+			? {
+					cookies: googleSession.cookies.filter(
+						(c: { domain: string }) =>
+							c.domain.includes('google.com'),
+					),
+					origins: [],
+				}
+			: undefined
+		context = await browser.newContext({ baseURL, storageState })
 		page = await context.newPage()
 
 		await injectSCWUrl(page)
@@ -47,6 +63,7 @@ test.describe('Google OAuth — RPC Methods', () => {
 		const sdkPopup = await waitForPopup(page, () =>
 			ethRequestAccounts.submit(),
 		)
+
 		await loginWithGoogle(sdkPopup)
 		await waitForPopupClose(sdkPopup)
 


### PR DESCRIPTION
### _Summary_

Add Google OAuth session storage to E2E tests to bypass Google's "Verify it's you" challenge in CI environments.

**Problem:** When E2E tests run from CI (different IP address than usual), Google detects the unfamiliar location and triggers a "Verify it's you" challenge. This blocks automated Google OAuth login and causes test failures.

**Solution:** Pre-save Google's authentication cookies (SID, HSID, etc.) and inject them into the browser context before the OAuth flow starts. With these cookies present, Google recognizes the session and skips the verification challenge.

**What changed:**

- **`e2e/scripts/save-google-session.ts`** (new) — Script that opens a headed browser, navigates to the testapp, and waits for manual Google login. After the popup closes, it saves the browser's `storageState` (cookies + localStorage) to `google-session.json`. Run with `pnpm save:google-session`.
- **`e2e/tests/google/rpc-methods.spec.ts`** — `beforeAll` now reads `GOOGLE_SESSION_STATE` env var, parses the JSON, filters to only Google domain cookies via an explicit `isGoogleDomain()` helper (excluding SCW/Dynamic Auth/privy cookies so the normal login flow still runs from a clean state), and passes them as `storageState` to the browser context.
- **`e2e/lib/auth/google-oauth.ts`** — Refactored `loginWithGoogle` into two parts:
  - Extracted `completeGoogleOAuthForm()` for the email → password → 2FA form.
  - `loginWithGoogle()` now uses `Promise.race` to detect whether Google auto-authenticates (redirect back to SCW) or shows the login form. This handles both the session-cookie path and the manual-login path.
  - Also supports the "Google" button variant (sign-up page) in addition to "Log in with Google" (login page).
- **`.github/workflows/e2e-tests.yaml`** — Added `GOOGLE_SESSION_STATE` secret to the CI workflow environment.
- **`.gitignore`** — Added `google-session.json` and `docs/` to prevent committing sensitive session data.
- **`e2e/package.json`** — Added `save:google-session` script.

### _How did you test your changes?_

- [x] Run `pnpm save:google-session` to generate `google-session.json` via manual browser login
- [x] Run Google OAuth E2E tests locally with session: `GOOGLE_SESSION_STATE=$(cat e2e/google-session.json) pnpm test:ci:google`
- [x] Run Google OAuth E2E tests locally without session (fallback path): `pnpm test:ci:google`
- [x] Verify CI workflow passes with `GOOGLE_SESSION_STATE` secret configured in GitHub
