### PR TITLE
Fix race condition in waitForPopupClose

### DIFF
--- a/e2e/lib/helpers.ts
+++ b/e2e/lib/helpers.ts
@@ -89,8 +89,11 @@ export const waitForPopup = async (
 
 /**
  * Wait for a popup to close (e.g. after auth completes).
+ * Guards against race: if the popup already closed before this is called,
+ * waitForEvent('close') would hang forever.
  */
 export const waitForPopupClose = async (popup: Page): Promise<void> => {
+	if (popup.isClosed()) return
 	await popup.waitForEvent('close')
 }
 


### PR DESCRIPTION
## Summary
- Guard `waitForPopupClose` with `popup.isClosed()` before calling `waitForEvent('close')`
- If the popup already closed before the call, `waitForEvent` hangs forever since the event already fired
- This matches the pattern already used in `approveSDKPopup`

## Context
Flaky `sdk-e2e / google` CI failures in superapp: on retry #1, `beforeAll` calls `waitForPopupClose(sdkPopup)` after Google OAuth, but the popup has already closed → 60s timeout → `personal_sign` test marked failed (0ms, body never ran).

Example: https://github.com/StartaleGroup/superapp/actions/runs/23883580601/job/69641946564?pr=1273