### PR TITLE
ERC-6492 signature validation

### DIFF
--- a/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
@@ -1,7 +1,21 @@
-import { Address, Chain, Hex, concat, createPublicClient, domainSeparator, hashTypedData, http, keccak256 } from 'viem';
+import {
+  Address,
+  Chain,
+  Hex,
+  concat,
+  createPublicClient,
+  domainSeparator,
+  encodeAbiParameters,
+  erc6492SignatureValidatorByteCode,
+  hashTypedData,
+  http,
+  isErc6492Signature,
+  keccak256,
+  parseAbiParameters
+} from 'viem';
 
-import { parseMessage } from '../shortcut/ShortcutType'
-import { RpcRequestInput } from './RpcRequestInput'
+import { parseMessage } from '../shortcut/ShortcutType';
+import { RpcRequestInput } from './RpcRequestInput';
 
 const ethSign: RpcRequestInput = {
 	method: 'eth_sign',
@@ -115,6 +129,35 @@ export const verifySignMsg = async ({
       const messageHash = hashTypedData(typedData);
       const finalHash = keccak256(concat(['0x1901', appDomainSeparator, messageHash]));
 
+      // For ERC-6492 signatures (undeployed accounts), use the Universal
+      // Signature Validator which deploys the account in a single eth_call
+      // simulation, then calls isValidSignature on the deployed contract.
+      const sig = sign as Hex;
+      if (isErc6492Signature(sig)) {
+        try {
+          // abi.encode(address signer, bytes32 hash, bytes wrappedSignature)
+          const callData = encodeAbiParameters(
+            parseAbiParameters(['address', 'bytes32', 'bytes']),
+            [from as Address, finalHash, sig],
+          );
+          // Simulate the universal validator via eth_call (read-only,
+          // nothing deployed on-chain). The validator bytecode runs
+          // account deployment + isValidSignature in a single call.
+          const { data } = await publicClient.call({
+            data: concat([erc6492SignatureValidatorByteCode as Hex, callData]),
+          });
+
+          // The validator returns abi.encode(bool) — 32 bytes, last byte is 0/1
+          const valid = data?.slice(-1) === '1';
+          if (valid) {
+            return `SigUtil Successfully verified signer as ${from} (ERC-6492)`;
+          }
+          return 'SigUtil Failed to verify signer (ERC-6492)';
+        } catch (error) {
+          return `Error verifying ERC-6492 signature: ${error}`;
+        }
+      }
+
       try {
         const response = await publicClient.readContract({
           address: from as Address,
@@ -131,6 +174,7 @@ export const verifySignMsg = async ({
           ],
           functionName: 'isValidSignature',
           args: [finalHash, sign as Hex],
+          authorizationList: undefined,
         });
 
         const valid = response === eip1271MagicValue;

--- a/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
@@ -12,10 +12,10 @@ import {
   isErc6492Signature,
   keccak256,
   parseAbiParameters
-} from 'viem';
+} from 'viem'
 
-import { parseMessage } from '../shortcut/ShortcutType';
-import { RpcRequestInput } from './RpcRequestInput';
+import { parseMessage } from '../shortcut/ShortcutType'
+import { RpcRequestInput } from './RpcRequestInput'
 
 const ethSign: RpcRequestInput = {
 	method: 'eth_sign',
@@ -147,14 +147,18 @@ export const verifySignMsg = async ({
             data: concat([erc6492SignatureValidatorByteCode as Hex, callData]),
           });
 
-          // The validator returns abi.encode(bool) — 32 bytes, last byte is 0/1
-          const valid = data?.slice(-1) === '1';
+          // The validator returns a single success byte (0x01 = valid, 0x00 = invalid)
+          if (!data) {
+            return 'SigUtil ERC-6492 validator returned no data';
+          }
+          const valid = Number(data) === 1;
           if (valid) {
             return `SigUtil Successfully verified signer as ${from} (ERC-6492)`;
           }
           return 'SigUtil Failed to verify signer (ERC-6492)';
         } catch (error) {
-          return `Error verifying ERC-6492 signature: ${error}`;
+          const message = error instanceof Error ? error.message : String(error);
+          return `Error verifying ERC-6492 signature: ${message}`;
         }
       }
 

--- a/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
@@ -151,7 +151,7 @@ export const verifySignMsg = async ({
           if (!data) {
             return 'SigUtil ERC-6492 validator returned no data';
           }
-          const valid = Number(data) === 1;
+          const valid = data === '0x01';
           if (valid) {
             return `SigUtil Successfully verified signer as ${from} (ERC-6492)`;
           }
@@ -178,6 +178,7 @@ export const verifySignMsg = async ({
           ],
           functionName: 'isValidSignature',
           args: [finalHash, sign as Hex],
+          // Silences viem 2.x type warning that expects authorizationList
           authorizationList: undefined,
         });
 


### PR DESCRIPTION
### _Summary_

Adds ERC-6492 signature validation support to the testapp's `verifySignMsg` helper.

ERC-6492 signatures are produced by undeployed smart contract wallets (e.g. a fresh SCW that has not yet been deployed on-chain). The standard `isValidSignature` contract call would fail for these accounts because no contract exists yet.

**What changed** (`examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts`):

- Import viem helpers: `encodeAbiParameters`, `erc6492SignatureValidatorByteCode`, `isErc6492Signature`, `parseAbiParameters`.
- In `verifySignMsg`, detect ERC-6492 signatures with `isErc6492Signature` before falling back to the existing EIP-1271 path.
- When an ERC-6492 signature is detected, encode `(address signer, bytes32 hash, bytes wrappedSignature)` and simulate the Universal Signature Validator bytecode via `publicClient.call`. The validator deploys the account and calls `isValidSignature` in a single read-only `eth_call` — nothing is deployed on-chain.
- Parse the `bool` result from the returned ABI-encoded data and return a human-readable verification message.
- Add `authorizationList: undefined` to the fallback `readContract` call to silence a viem type warning.

### _How did you test your changes?_

- Tested manually in the testapp by connecting a fresh (undeployed) SCW account, signing a typed-data message, and running `verifySignMsg`. The ERC-6492 path returns `"SigUtil Successfully verified signer as <address> (ERC-6492)"`.
<img width="480" height="146" alt="image" src="https://github.com/user-attachments/assets/9bba3443-4d3f-4766-b723-2dd87109cf41" />

- Verified that standard EIP-1271 signatures for deployed accounts still go through the existing `readContract` path without regression.
<img width="474" height="125" alt="image" src="https://github.com/user-attachments/assets/33f67004-6304-4823-a3f8-1138ab756f17" />

