### PR TITLE
fix: security hardening — externalize API key, harden code sanitizer,…

### DIFF
--- a/examples/testapp/package.json
+++ b/examples/testapp/package.json
@@ -23,7 +23,7 @@
 		"@types/acorn": "^4.0.6",
 		"acorn": "^8.15.0",
 		"framer-motion": "^10.13.1",
-		"next": "^14.2.10",
+		"next": "^14.2.35",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-hook-form": "7.45.2",

--- a/examples/testapp/src/pages/pay-playground/utils/codeSanitizer.ts
+++ b/examples/testapp/src/pages/pay-playground/utils/codeSanitizer.ts
@@ -60,7 +60,6 @@ export const WHITELIST = {
 		'ObjectPattern', // Added: Object destructuring
 		'ArrayPattern', // Added: Array destructuring
 		'RestElement', // Added: Rest parameters
-		'ThisExpression', // Added: 'this' keyword
 		'ChainExpression', // Added: Optional chaining
 		'OptionalMemberExpression', // Added: Optional member access
 		'OptionalCallExpression', // Added: Optional function calls
@@ -79,6 +78,8 @@ export const WHITELIST = {
 		'export',
 		'process',
 		'global',
+		'globalThis',
+		'self',
 		'window',
 		'document',
 		'XMLHttpRequest',
@@ -105,6 +106,14 @@ export const WHITELIST = {
 		'clearInterval',
 		'clearTimeout',
 		'clearImmediate',
+		'Proxy',
+		'Reflect',
+		'constructor',
+		'__proto__',
+		'__defineGetter__',
+		'__defineSetter__',
+		'__lookupGetter__',
+		'__lookupSetter__',
 	],
 }
 
@@ -298,6 +307,16 @@ export class CodeSanitizer {
 		}
 	}
 
+	private static readonly DANGEROUS_PROPERTIES = [
+		'constructor',
+		'__proto__',
+		'prototype',
+		'__defineGetter__',
+		'__defineSetter__',
+		'__lookupGetter__',
+		'__lookupSetter__',
+	]
+
 	/**
 	 * Validate member expressions (object.property)
 	 */
@@ -319,6 +338,19 @@ export class CodeSanitizer {
 			propertyName = node.computed ? '' : node.property.name
 		} else if (node.property.type === 'Literal') {
 			propertyName = String(node.property.value)
+		}
+
+		// Block prototype-chain traversal properties on any object
+		if (
+			propertyName &&
+			CodeSanitizer.DANGEROUS_PROPERTIES.includes(propertyName)
+		) {
+			this.errors.push({
+				message: `Property '${propertyName}' is not allowed`,
+				line: node.loc?.start.line ? node.loc.start.line - 1 : undefined,
+				column: node.loc?.start.column,
+			})
+			return
 		}
 
 		// Validate against whitelist

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
 	"packageManager": "pnpm@10.32.1",
 	"pnpm": {
 		"overrides": {
-			"basic-ftp": ">=5.2.0"
+			"basic-ftp": ">=5.2.0",
+			"@isaacs/brace-expansion": ">=5.0.1"
 		}
 	}
 }

--- a/packages/app-sdk/package.json
+++ b/packages/app-sdk/package.json
@@ -97,7 +97,7 @@
 		"@vitest/coverage-v8": "2.1.9",
 		"@vitest/web-worker": "^2.1.9",
 		"fake-indexeddb": "^6.0.0",
-		"glob": "^11.0.0",
+		"glob": "^11.1.0",
 		"jest-websocket-mock": "^2.4.0",
 		"jsdom": "^25.0.1",
 		"nodemon": "^3.1.0",

--- a/packages/app-sdk/src/core/telemetry/initCCA.test.ts
+++ b/packages/app-sdk/src/core/telemetry/initCCA.test.ts
@@ -116,7 +116,7 @@ describe('initCCA', () => {
 
 			expect(mockClientAnalytics.init).toHaveBeenCalledWith({
 				isProd: true,
-				amplitudeApiKey: 'c66737ad47ec354ced777935b0af822e',
+				amplitudeApiKey: 'EXAMPLE_TOKEN',
 				platform: 'web',
 				projectName: 'base_account_sdk',
 				showDebugLogging: false,

--- a/packages/app-sdk/src/core/telemetry/initCCA.ts
+++ b/packages/app-sdk/src/core/telemetry/initCCA.ts
@@ -1,6 +1,10 @@
 import { store } from ':store/store.js'
 import { TELEMETRY_SCRIPT_CONTENT } from './telemetry-content.js'
 
+const AMPLITUDE_API_KEY =
+	(typeof process !== 'undefined' && process.env?.AMPLITUDE_API_KEY) ||
+	'EXAMPLE_TOKEN'
+
 export const loadTelemetryScript = (): Promise<void> => {
 	return new Promise((resolve, reject) => {
 		if (window.ClientAnalytics) {
@@ -34,7 +38,7 @@ const initCCA = () => {
 
 			init({
 				isProd: true,
-				amplitudeApiKey: 'c66737ad47ec354ced777935b0af822e',
+				amplitudeApiKey: AMPLITUDE_API_KEY,
 				platform: PlatformName.web,
 				projectName: 'base_account_sdk',
 				showDebugLogging: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   basic-ftp: '>=5.2.0'
+  '@isaacs/brace-expansion': '>=5.0.1'
 
 importers:
 
@@ -79,8 +80,8 @@ importers:
         specifier: ^10.13.1
         version: 10.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next:
-        specifier: ^14.2.10
-        version: 14.2.33(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2)
+        specifier: ^14.2.35
+        version: 14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -180,8 +181,8 @@ importers:
         specifier: ^6.0.0
         version: 6.2.4
       glob:
-        specifier: ^11.0.0
-        version: 11.0.3
+        specifier: ^11.1.0
+        version: 11.1.0
       jest-websocket-mock:
         specifier: ^2.4.0
         version: 2.5.0
@@ -790,14 +791,6 @@ packages:
     peerDependencies:
       typescript: 5.8.3
 
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
-
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -842,8 +835,8 @@ packages:
     resolution: {integrity: sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==}
     engines: {node: '>=16.0.0'}
 
-  '@next/env@14.2.33':
-    resolution: {integrity: sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==}
+  '@next/env@14.2.35':
+    resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
 
   '@next/swc-darwin-arm64@14.2.33':
     resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
@@ -1707,6 +1700,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.1:
     resolution: {integrity: sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ==}
     peerDependencies:
@@ -1774,6 +1771,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2392,8 +2393,8 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@11.0.3:
-    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
@@ -2776,9 +2777,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2842,10 +2843,9 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
-  next@14.2.33:
-    resolution: {integrity: sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==}
+  next@14.2.35:
+    resolution: {integrity: sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==}
     engines: {node: '>=18.17.0'}
-    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -4516,12 +4516,6 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
-
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -4590,7 +4584,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@next/env@14.2.33': {}
+  '@next/env@14.2.35': {}
 
   '@next/swc-darwin-arm64@14.2.33':
     optional: true
@@ -5416,6 +5410,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.1: {}
 
   bare-fs@4.5.0:
@@ -5481,6 +5477,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -6077,11 +6077,11 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.3:
+  glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.0.3
+      minimatch: 10.2.5
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
@@ -6472,9 +6472,9 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@10.0.3:
+  minimatch@10.2.5:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      brace-expansion: 5.0.6
 
   minimatch@3.1.2:
     dependencies:
@@ -6516,9 +6516,9 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@14.2.33(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2):
+  next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2):
     dependencies:
-      '@next/env': 14.2.33
+      '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
       caniuse-lite: 1.0.30001751


### PR DESCRIPTION
… upgrade vulnerable deps

- Remove hardcoded Amplitude API key from initCCA.ts; read from AMPLITUDE_API_KEY env var with EXAMPLE_TOKEN fallback
- Harden pay playground code sanitizer:
  - Block globalThis, self, Proxy, Reflect, constructor, __proto__ and other prototype-chain traversal globals
  - Block ThisExpression to prevent scope escape
  - Add DANGEROUS_PROPERTIES check on all member expressions
- Upgrade vulnerable dependencies:
  - glob ^11.0.0 → ^11.1.0 (command injection fix)
  - next ^14.2.10 → ^14.2.35 (3 DoS CVEs)
  - @isaacs/brace-expansion override >=5.0.1 (ReDoS fix)

### _Summary_

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
