### PR TITLE
Paymaster proxy example

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -185,10 +185,25 @@ jobs:
       - name: Start Cloudflare tunnel
         env:
           CLOUDFLARE_TUNNEL_TOKEN: ${{ secrets.CLOUDFLARE_TUNNEL_TOKEN }}
+          # Pinned for reproducibility + supply-chain safety. Bump both together;
+          # digest is the GitHub asset digest for cloudflared-linux-amd64.
+          CLOUDFLARED_VERSION: '2026.6.1'
+          CLOUDFLARED_SHA256: '5861a10a438fe8ddcfebb3b830f83966cbf193edafce0fe2eeb198fbae1f7a22'
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+          set -euo pipefail
+          # Fail fast with a clear message if the sponsored-test config is absent,
+          # rather than starting the tunnel and failing opaquely later.
+          : "${CLOUDFLARE_TUNNEL_TOKEN:?CLOUDFLARE_TUNNEL_TOKEN is required for the sponsored e2e tunnel}"
+          : "${NEXT_PUBLIC_PAYMASTER_BASE_URL:?NEXT_PUBLIC_PAYMASTER_BASE_URL (vars.PAYMASTER_BASE_URL) is required}"
+          : "${PAYMASTER_URL:?PAYMASTER_URL is required}"
+          : "${PAYMASTER_ID:?PAYMASTER_ID is required}"
+
+          curl -fsSL \
+            "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64" \
             -o /usr/local/bin/cloudflared
+          echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
           chmod +x /usr/local/bin/cloudflared
+
           cloudflared tunnel --no-autoupdate --metrics 127.0.0.1:4040 \
             run --token "$CLOUDFLARE_TUNNEL_TOKEN" &
           echo "Waiting for tunnel connector to register..."

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -25,6 +25,12 @@ on:
         required: false
       LINE_SESSION_STATE:
         required: false
+      CLOUDFLARE_TUNNEL_TOKEN:
+        required: false
+      PAYMASTER_URL:
+        required: false
+      PAYMASTER_ID:
+        required: false
       WALLET_SEED:
         required: true
       EOA_LINKED_WALLET_SEED:
@@ -141,10 +147,23 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.58.0-noble
     timeout-minutes: 30
+    # Named tunnel = one connector per token. Serialize the line job repo-wide
+    # so concurrent runs (different PRs) can't register two connectors on the
+    # same tunnel (Cloudflare 1016). Queue rather than cancel.
+    concurrency:
+      group: e2e-line-tunnel
+      cancel-in-progress: false
     env:
       LINE_TEST_EMAIL: ${{ secrets.LINE_TEST_EMAIL }}
       LINE_TEST_PASSWORD: ${{ secrets.LINE_TEST_PASSWORD }}
       LINE_SESSION_STATE: ${{ secrets.LINE_SESSION_STATE }}
+      # Sponsored wallet_sendCalls. PAYMASTER_* stay server-side (testapp proxy);
+      # NEXT_PUBLIC_PAYMASTER_BASE_URL is the public tunnel host the prod superapp
+      # fetches to reach the testapp paymaster proxy. Required — the sponsored
+      # test fails (does not skip) if it is missing.
+      PAYMASTER_URL: ${{ secrets.PAYMASTER_URL }}
+      PAYMASTER_ID: ${{ secrets.PAYMASTER_ID }}
+      NEXT_PUBLIC_PAYMASTER_BASE_URL: ${{ vars.PAYMASTER_BASE_URL }}
     steps:
       - uses: actions/checkout@v4
         if: inputs.superapp-branch != ''
@@ -157,6 +176,29 @@ jobs:
       - uses: ./.github/actions/e2e-setup
         with:
           install-chrome: 'true'
+
+      # Expose the testapp's same-origin paymaster proxy (localhost:3001) on a
+      # public hostname so the prod superapp can reach it for sponsored calls.
+      # The SCS key stays server-side in the testapp route — only the public
+      # host is exposed. Readiness is the connector /ready endpoint (the testapp
+      # is started later by Playwright's webServer).
+      - name: Start Cloudflare tunnel
+        env:
+          CLOUDFLARE_TUNNEL_TOKEN: ${{ secrets.CLOUDFLARE_TUNNEL_TOKEN }}
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+            -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+          cloudflared tunnel --no-autoupdate --metrics 127.0.0.1:4040 \
+            run --token "$CLOUDFLARE_TUNNEL_TOKEN" &
+          echo "Waiting for tunnel connector to register..."
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:4040/ready >/dev/null 2>&1; then
+              echo "tunnel ready"; exit 0
+            fi
+            sleep 2
+          done
+          echo "tunnel did not become ready" >&2; exit 1
 
       - name: Start SuperApp
         if: inputs.superapp-branch != ''

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -183,6 +183,9 @@ jobs:
       # host is exposed. Readiness is the connector /ready endpoint (the testapp
       # is started later by Playwright's webServer).
       - name: Start Cloudflare tunnel
+        # Force bash: the container's default shell is `sh` (dash), which can't
+        # parse `set -o pipefail` below.
+        shell: bash
         env:
           CLOUDFLARE_TUNNEL_TOKEN: ${{ secrets.CLOUDFLARE_TUNNEL_TOKEN }}
           # Pinned for reproducibility + supply-chain safety. Bump both together;

--- a/examples/testapp/.env.local.example
+++ b/examples/testapp/.env.local.example
@@ -1,3 +1,6 @@
 # Soneium paymaster configuration for testapp.
 PAYMASTER_ID=
 PAYMASTER_URL=
+
+# public paymaster base url for testapp.
+NEXT_PUBLIC_PAYMASTER_BASE_URL=

--- a/examples/testapp/.env.local.example
+++ b/examples/testapp/.env.local.example
@@ -1,0 +1,3 @@
+# Soneium paymaster configuration for testapp.
+PAYMASTER_ID=
+PAYMASTER_URL=

--- a/examples/testapp/next.config.mjs
+++ b/examples/testapp/next.config.mjs
@@ -1,5 +1,9 @@
 export default {
-	output: 'export',
+	// `output: 'export'` is opt-in so the /api/paymaster proxy route works
+	// under normal `next dev` / `next build`. Set STATIC_EXPORT=true when you
+	// intend to deploy the playground as pure static files — the API route
+	// will then be omitted and you'll need an external proxy instead.
+	...(process.env.STATIC_EXPORT === 'true' ? { output: 'export' } : {}),
 	basePath: process.env.NODE_ENV === 'production' ? '/account-sdk' : undefined,
 	pageExtensions: ['page.tsx', 'page.ts', 'page.js', 'page.jsx'],
 	eslint: {

--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
@@ -46,10 +46,18 @@ export function EIP1193ProviderContextProvider({
 		// (`/api/paymaster/<chainId>`). The SCS API key and paymaster ID stay
 		// server-side — never exposed to the browser. See
 		// `src/pages/api/paymaster/[chainId].page.ts` and `.env.local.example`.
+		//
+		// `NEXT_PUBLIC_PAYMASTER_BASE_URL` overrides the base origin so the
+		// paymaster URL can resolve to a publicly reachable host (e.g. a
+		// Cloudflare tunnel) when the wallet/superapp runs off-machine and
+		// cannot reach `localhost` — required for sponsored e2e against prod.
+		// Only the public host is exposed; the SCS key still stays server-side.
 		const origin =
 			typeof window !== 'undefined' ? window.location.origin : ''
+		const paymasterBase =
+			process.env.NEXT_PUBLIC_PAYMASTER_BASE_URL || origin
 		const paymasterUrl = (chainId: number) =>
-			`${origin}/api/paymaster/${chainId}`
+			`${paymasterBase}/api/paymaster/${chainId}`
 
 		const sdkParams = {
 			appName: 'Startale app SDK Playground',

--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
@@ -42,9 +42,14 @@ export function EIP1193ProviderContextProvider({
 	const [provider, setProvider] = useState(null)
 
 	useEffect(() => {
-		const paymasterId = process.env.NEXT_PUBLIC_PAYMASTER_ID
-		const paymasterApiKey = process.env.NEXT_PUBLIC_PAYMASTER_API_KEY
-		const bundlerApiKey = process.env.NEXT_PUBLIC_BUNDLER_API_KEY
+		// Paymaster URL points at this app's same-origin proxy route
+		// (`/api/paymaster/<chainId>`). The SCS API key and paymaster ID stay
+		// server-side — never exposed to the browser. See
+		// `src/pages/api/paymaster/[chainId].page.ts` and `.env.local.example`.
+		const origin =
+			typeof window !== 'undefined' ? window.location.origin : ''
+		const paymasterUrl = (chainId: number) =>
+			`${origin}/api/paymaster/${chainId}`
 
 		const sdkParams = {
 			appName: 'Startale app SDK Playground',
@@ -58,10 +63,16 @@ export function EIP1193ProviderContextProvider({
 				authType: undefined,
 			},
 			subAccounts: subAccountsConfig,
-			paymasterOptions: paymasterId && paymasterApiKey ? {	
-				[soneium.id]: {url: `https://paymaster.scs.startale.com/v1?apikey=${paymasterApiKey}`, 
-				id: paymasterId}
-			} : undefined,
+			// `id` is read by the SDK but the proxy injects the paymaster ID
+			// into the upstream SCS request itself, so we leave it empty.
+			// SCS sponsors Soneium networks only — mainnet (ETH) is omitted.
+			paymasterOptions: {
+				[soneium.id]: { url: paymasterUrl(soneium.id), id: '' },
+				[soneiumMinato.id]: {
+					url: paymasterUrl(soneiumMinato.id),
+					id: '',
+				},
+			},
 		}
 
 		const sdk = createStartaleAccountSDKHEAD(sdkParams)

--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.tsx
@@ -54,8 +54,10 @@ export function EIP1193ProviderContextProvider({
 		// Only the public host is exposed; the SCS key still stays server-side.
 		const origin =
 			typeof window !== 'undefined' ? window.location.origin : ''
-		const paymasterBase =
+		// Strip trailing slash(es)
+		const paymasterBase = (
 			process.env.NEXT_PUBLIC_PAYMASTER_BASE_URL || origin
+		).replace(/\/+$/, '')
 		const paymasterUrl = (chainId: number) =>
 			`${paymasterBase}/api/paymaster/${chainId}`
 

--- a/examples/testapp/src/pages/api/paymaster/[chainId].page.ts
+++ b/examples/testapp/src/pages/api/paymaster/[chainId].page.ts
@@ -1,0 +1,124 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+// Startale Cloud Services (SCS) paymaster proxy.
+//
+// Why this exists:
+//   The Startale App SDK takes a `paymasterOptions[chainId].url`. The SCS
+//   paymaster URL embeds the API key as a query param
+//   (`?apikey=...`); if the dApp passed that URL directly the key would be
+//   visible in DevTools to every user. Instead, the dApp exposes a
+//   same-origin proxy URL and keeps the SCS API key server-side.
+//
+// The proxy:
+//   1. Receives the JSON-RPC body the wallet sends to the paymaster
+//      (ERC-7677 `pm_getPaymasterStubData` / `pm_getPaymasterData`).
+//   2. Injects `context: { paymasterId }` so the dApp's provisioned SCS
+//      paymaster policy is applied.
+//   3. Forwards to SCS with the API key in the query string.
+//
+// Production apps should also authenticate the caller here (session cookie,
+// signed message, etc.) before forwarding — anyone hitting this route can
+// spend sponsorship budget within the policy limits.
+
+// SCS paymaster supports Soneium networks. The chain is conveyed by the
+// `chainId` argument inside the JSON-RPC call, not the endpoint — this set
+// only guards against forwarding requests for unsupported chains.
+const SUPPORTED_CHAIN_IDS = new Set([
+	1868, // Soneium mainnet
+	1946, // Soneium Minato testnet
+])
+
+const PAYMASTER_METHODS = new Set(['pm_getPaymasterData', 'pm_getPaymasterStubData'])
+
+type JsonRpcRequest = {
+	jsonrpc?: string
+	id?: number | string | null
+	method?: string
+	params?: unknown[]
+}
+
+const setCors = (res: NextApiResponse): void => {
+	res.setHeader('Access-Control-Allow-Origin', '*')
+	res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+	res.setHeader('Access-Control-Allow-Headers', 'content-type')
+}
+
+// SCS API keys and paymaster IDs are provisioned per network in the SCS
+// portal. Prefer a chain-specific value, falling back to a shared one.
+const envForChain = (prefix: string, chainId: number): string | undefined =>
+	process.env[`${prefix}_${chainId}`] ?? process.env[prefix]
+
+const injectPaymasterId = (
+	body: JsonRpcRequest,
+	paymasterId: string,
+): JsonRpcRequest => {
+	if (!body.method || !PAYMASTER_METHODS.has(body.method)) return body
+	if (!Array.isArray(body.params) || body.params.length === 0) return body
+
+	const last = body.params[body.params.length - 1]
+	const isContext = typeof last === 'object' && last !== null && !Array.isArray(last)
+	const existingContext = (isContext ? (last as Record<string, unknown>) : {}) as {
+		paymasterId?: string
+	}
+
+	const mergedContext = {
+		...existingContext,
+		paymasterId: existingContext.paymasterId ?? paymasterId,
+	}
+	const params = isContext
+		? [...body.params.slice(0, -1), mergedContext]
+		: [...body.params, mergedContext]
+
+	return { ...body, params }
+}
+
+export default async function handler(
+	req: NextApiRequest,
+	res: NextApiResponse,
+): Promise<void> {
+	setCors(res)
+
+	if (req.method === 'OPTIONS') {
+		res.status(204).end()
+		return
+	}
+
+	if (req.method !== 'POST') {
+		res.status(405).json({ error: 'method not allowed' })
+		return
+	}
+
+	const chainIdParam = Array.isArray(req.query.chainId)
+		? req.query.chainId[0]
+		: req.query.chainId
+	const chainId = Number(chainIdParam)
+
+	if (!SUPPORTED_CHAIN_IDS.has(chainId)) {
+		res.status(400).json({ error: `unsupported chainId: ${chainIdParam}` })
+		return
+	}
+
+	const paymasterUrl = envForChain('PAYMASTER_URL', chainId)
+	const paymasterId = envForChain('PAYMASTER_ID', chainId)
+
+	if (!paymasterUrl || !paymasterId) {
+		res.status(500).json({
+			error: 'paymaster not configured: set PAYMASTER_URL and PAYMASTER_ID',
+		})
+		return
+	}
+
+	const body = (req.body ?? {}) as JsonRpcRequest
+	const upstreamBody = injectPaymasterId(body, paymasterId)
+
+	const upstream = await fetch(paymasterUrl, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(upstreamBody),
+	})
+
+	const text = await upstream.text()
+	res.status(upstream.status)
+	res.setHeader('content-type', upstream.headers.get('content-type') ?? 'application/json')
+	res.send(text)
+}

--- a/examples/testapp/src/pages/api/paymaster/[chainId].page.ts
+++ b/examples/testapp/src/pages/api/paymaster/[chainId].page.ts
@@ -37,8 +37,14 @@ type JsonRpcRequest = {
 	params?: unknown[]
 }
 
+// Allowed CORS origin. Defaults to `*` for local dev; set
+// `PAYMASTER_ALLOWED_ORIGIN` in deployments to lock the proxy down so arbitrary
+// third-party sites can't invoke it from a browser and consume sponsorship.
 const setCors = (res: NextApiResponse): void => {
-	res.setHeader('Access-Control-Allow-Origin', '*')
+	res.setHeader(
+		'Access-Control-Allow-Origin',
+		process.env.PAYMASTER_ALLOWED_ORIGIN ?? '*',
+	)
 	res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
 	res.setHeader('Access-Control-Allow-Headers', 'content-type')
 }
@@ -109,13 +115,34 @@ export default async function handler(
 	}
 
 	const body = (req.body ?? {}) as JsonRpcRequest
+
+	// This route exists only to proxy ERC-7677 paymaster calls. Reject anything
+	// else so it can't be used to relay arbitrary JSON-RPC to the SCS endpoint.
+	if (!body.method || !PAYMASTER_METHODS.has(body.method)) {
+		res.status(400).json({
+			error: `unsupported paymaster method: ${body.method ?? '(none)'}`,
+		})
+		return
+	}
+
 	const upstreamBody = injectPaymasterId(body, paymasterId)
 
-	const upstream = await fetch(paymasterUrl, {
-		method: 'POST',
-		headers: { 'content-type': 'application/json' },
-		body: JSON.stringify(upstreamBody),
-	})
+	let upstream: Response
+	try {
+		upstream = await fetch(paymasterUrl, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(upstreamBody),
+		})
+	} catch (err) {
+		// Network-level failure reaching SCS (DNS, timeout, refused). Surface a
+		// 502 with detail instead of a generic Next 500 so it's debuggable.
+		res.status(502).json({
+			error: 'paymaster upstream unreachable',
+			detail: err instanceof Error ? err.message : String(err),
+		})
+		return
+	}
 
 	const text = await upstream.text()
 	res.status(upstream.status)


### PR DESCRIPTION
### _Summary_

This PR brings example on how to proxy paymaster and provide paymaster url to Startale app SDK

Proxying is important to hide paymaster secrets.
App developers still needs to set up a proper paymaster policy since the paymaster URL is visible to all app users.

### _How did you test your changes?_

<img width="409" height="383" alt="image" src="https://github.com/user-attachments/assets/5287f8a4-e2a4-41a0-88f2-18e14162c2a7" />
